### PR TITLE
Add !from_yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ This tells SCUBA:
 - `build` is an alias for `make -j4`.
 In this example, `scuba build foo` would execute `make -j4 foo` in a `gcc:5.1` container.
 
+### Extended syntax
+In addition to normal YAML syntax, an additional constructor, `!from_yaml`, is available for `.scuba.yml` which allows a key to be retrieved from an external YAML file. Is has the following syntax:
+```yaml
+!from_yaml filename key
+```
+where `filename` is the path of an external YAML file, and `key` is a dot-separated locator of the key to retrieve.
+
+This is useful for projects where a Docker image in which to build is already specified in another YAML file, for example in [`.gitlab-ci.yml`](http://doc.gitlab.com/ce/ci/yaml/README.html). This eliminates the redundancy between the configuration files. An example which uses this:
+
+**`.gitlab-ci.yml`**
+```yaml
+image: gcc:5.1
+# ...
+```
+
+**`.scuba.yml`**
+```yaml
+image: !from_yaml .gitlab-ci.yml image
+```
+
+
 ## License
 
 This software is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/example/external_yaml_nested/.other.yml
+++ b/example/external_yaml_nested/.other.yml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    image: busybox 

--- a/example/external_yaml_nested/.scuba.yml
+++ b/example/external_yaml_nested/.scuba.yml
@@ -1,0 +1,1 @@
+image: !from_yaml .other.yml foo.bar.image

--- a/example/external_yaml_simple/.other.yml
+++ b/example/external_yaml_simple/.other.yml
@@ -1,0 +1,1 @@
+image: busybox

--- a/example/external_yaml_simple/.scuba.yml
+++ b/example/external_yaml_simple/.scuba.yml
@@ -1,0 +1,1 @@
+image: !from_yaml .other.yml image

--- a/src/scuba
+++ b/src/scuba
@@ -19,6 +19,57 @@ BUILD_DIR = '/build'
 def appmsg(fmt, *args):
     print 'scuba: ' + fmt.format(*args)
 
+
+# http://stackoverflow.com/a/9577670
+class Loader(yaml.Loader):
+    def __init__(self, stream):
+        self._root = os.path.split(stream.name)[0]
+        super(Loader, self).__init__(stream)
+
+    def from_yaml(self, node):
+        '''
+        Implementes a !from_yaml constructor with the following syntax:
+            !from_yaml filename key
+
+        Arguments:
+            filename:   Filename of external YAML document from which to load,
+                        relative to the current YAML file.
+            key:        Key from external YAML document to return,
+                        using a dot-separated syntax for nested keys.
+
+        Examples:
+            !from_yaml external.yml pop
+            !from_yaml external.yml foo.bar.pop
+            !from_yaml "another file.yml" "foo bar.snap crackle.pop"
+        '''
+        # Load the content from the node, as a scalar
+        content = self.construct_scalar(node)
+
+        # Split on unquoted spaces
+        parts = shlex.split(content)
+        if len(parts) != 2:
+            raise yaml.YAMLError('Two arguments expected to !from_yaml')
+        filename, key = parts
+
+        # path is relative to the current YAML document
+        path = os.path.join(self._root, filename)
+
+        # Load the other YAML document
+        with open(path, 'r') as f:
+            doc = yaml.load(f, self.__class__)
+
+        # Retrieve the key
+        try:
+            cur = doc
+            for k in key.split('.'):
+                cur = cur[k]
+        except KeyError:
+            raise yaml.YAMLError('Key "{0}" not found in {1}'.format(key, filename))
+        return cur
+
+Loader.add_constructor('!from_yaml', Loader.from_yaml)
+
+
 def find_config():
     '''Search up the diretcory hierarchy for .scuba.yml
 
@@ -51,11 +102,10 @@ def find_config():
     appmsg('{0} not found here or any parent directories'.format(SCUBA_YML))
     sys.exit(128)
 
-
 def load_config(path):
-    try: 
+    try:
         with open(path) as f:
-            config = yaml.safe_load(f)
+            config = yaml.load(f, Loader)
     except IOError as e:
         appmsg('Error opening {0}: {1}', SCUBA_YML, e)
         sys.exit(2)


### PR DESCRIPTION
This adds a `!from_yaml` constructor to the YAML loader. With this one can specify the `image` in `.scuba.yml` by referring to a key in another YAML file.

This closes #7.