### PR TITLE
Change working directory name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Change working directory from /build to /scubaroot
 
 ## [1.2.0] - 2015-12-27
 ### Added

--- a/src/scuba
+++ b/src/scuba
@@ -15,7 +15,7 @@ import argparse
 __version__ = '1.2.0'
 
 SCUBA_YML = '.scuba.yml'
-BUILD_DIR = '/build'
+SCUBA_ROOT = '/scubaroot'
 
 def appmsg(fmt, *args):
     print 'scuba: ' + fmt.format(*args)
@@ -183,10 +183,10 @@ def main():
         # Mount build directory...
         # NOTE: This tells Docker to re-label the directory for compatibility
         # with SELinux. See `man docker-run` for more information.
-        make_vol_opt(top_path, BUILD_DIR, 'z'),
+        make_vol_opt(top_path, SCUBA_ROOT, 'z'),
 
         # ...and set the working dir there
-        '-w', os.path.join(BUILD_DIR, top_rel),
+        '-w', os.path.join(SCUBA_ROOT, top_rel),
     ]
 
     # Run as the current user:group


### PR DESCRIPTION
This changes the in-container working directory from `/build` to `/scubaroot`.

This is more general (scuba doesn't *have* to be related to "building"), and clear (indicates that scuba was the one who set it up).