### PR TITLE
Add .scubainit

### DIFF
--- a/src/scuba
+++ b/src/scuba
@@ -163,7 +163,11 @@ def shell_quote(s):
     return pipes.quote(s)
 
 def generate_scubainit(config, command):
+    # Expand any aliases
     command = process_command(config, command)
+
+    # Turn command into a string which you would enter in a shell
+    command = ' '.join(shell_quote(c) for c in command)
 
     with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
         atexit.register(os.remove, f.name)
@@ -175,8 +179,6 @@ def generate_scubainit(config, command):
             f.write(' '.join(c for c in args) + '\n')
 
         write_cmd('#!/bin/sh')
-
-        write_cmd('echo', shell_quote('hello from scubainit'))
 
         # Add scubauser with current uid/gid
         # BusyBox only has 'adduser', with arguments incompatible with
@@ -193,11 +195,8 @@ def generate_scubainit(config, command):
             )
         write_cmd('echo', shell_quote(entry), '>>', '/etc/passwd')
 
-        write_cmd('su', SCUBA_USER)
-
-        # Finally, execute the command indicated by the user
-        command = [shell_quote(c) for c in command]
-        write_cmd(*command)
+        # Execute the command indicated by the user, as the scuba user
+        write_cmd('su', SCUBA_USER, '-c', shell_quote(command))
 
         return f.name
 
@@ -221,7 +220,6 @@ def main():
     config = load_config(os.path.join(top_path, SCUBA_YML))
 
     scubainit_path = generate_scubainit(config, args.command)
-    #os._exit(66)
 
     run_args = ['docker', 'run',
         # interactive: keep STDIN open

--- a/src/scuba
+++ b/src/scuba
@@ -20,6 +20,7 @@ __version__ = '1.2.0'
 SCUBA_YML = '.scuba.yml'
 SCUBA_ROOT = '/scubaroot'
 SCUBA_USER = 'scubauser'
+SCUBA_GROUP = SCUBA_USER
 
 def appmsg(fmt, *args):
     print 'scuba: ' + fmt.format(*args)
@@ -158,6 +159,13 @@ def make_vol_opt(hostdir, contdir, options=None):
 def passwd_entry(**kw):
     return '{username}:{password}:{uid}:{gid}:{gecos}:{homedir}:{shell}'.format(**kw)
 
+def group_entry(groupname, password, gid, users=[]):
+    return '{groupname}:{password}:{gid}:{users}'.format(
+            groupname = groupname,
+            password = password,
+            gid = gid,
+            users = ','.join(users))
+
 def shell_quote(s):
     # http://stackoverflow.com/a/847800/119527
     return pipes.quote(s)
@@ -191,6 +199,15 @@ def generate_scubainit(config, command):
             shell = '/bin/sh',
             )
         write_cmd('echo', shell_quote(entry), '>>', '/etc/passwd')
+
+        # Add scubauser group
+        entry = group_entry(
+            groupname = SCUBA_GROUP,
+            password = 'x',
+            gid = os.getgid(),
+            users = [SCUBA_USER],
+            )
+        write_cmd('echo', shell_quote(entry), '>>', '/etc/group')
 
         # Execute the command indicated by the user, as the scuba user
         write_cmd('su', SCUBA_USER, '-c', shell_quote(command))

--- a/src/scuba
+++ b/src/scuba
@@ -19,6 +19,7 @@ __version__ = '1.2.0'
 
 SCUBA_YML = '.scuba.yml'
 SCUBA_ROOT = '/scubaroot'
+SCUBA_USER = 'scubauser'
 
 def appmsg(fmt, *args):
     print 'scuba: ' + fmt.format(*args)
@@ -154,21 +155,49 @@ def make_vol_opt(hostdir, contdir, options=None):
         vol += ':' + ','.join(options)
     return vol
 
-def writeln(f, line):
-    f.write(line + '\n')
+def passwd_entry(**kw):
+    return '{username}:{password}:{uid}:{gid}:{gecos}:{homedir}:{shell}'.format(**kw)
+
+def shell_quote(s):
+    # http://stackoverflow.com/a/847800/119527
+    return pipes.quote(s)
 
 def generate_scubainit(config, command):
     command = process_command(config, command)
 
     with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
-        #atexit.register(os.remove, f.name)
+        atexit.register(os.remove, f.name)
 
         # TODO: What if we're not on Linux?
         os.chmod(f.name, 0777)
 
-        writeln(f, '#!/bin/sh')
-        writeln(f, 'echo "hello from scubainit"')
-        writeln(f, ' '.join(pipes.quote(c) for c in command))
+        def write_cmd(*args):
+            f.write(' '.join(c for c in args) + '\n')
+
+        write_cmd('#!/bin/sh')
+
+        write_cmd('echo', shell_quote('hello from scubainit'))
+
+        # Add scubauser with current uid/gid
+        # BusyBox only has 'adduser', with arguments incompatible with
+        # that of the standard 'useradd'.
+        # Instead, we'll just write the entry ourselves.
+        entry = passwd_entry(
+            username = SCUBA_USER,
+            password = 'x',
+            uid = os.getuid(),
+            gid = os.getgid(),
+            gecos = 'Scuba User',
+            homedir = '/',          # Docker sets $HOME=/
+            shell = '/bin/sh',
+            )
+        write_cmd('echo', shell_quote(entry), '>>', '/etc/passwd')
+
+        write_cmd('su', SCUBA_USER)
+
+        # Finally, execute the command indicated by the user
+        command = [shell_quote(c) for c in command]
+        write_cmd(*command)
 
         return f.name
 
@@ -192,6 +221,7 @@ def main():
     config = load_config(os.path.join(top_path, SCUBA_YML))
 
     scubainit_path = generate_scubainit(config, args.command)
+    #os._exit(66)
 
     run_args = ['docker', 'run',
         # interactive: keep STDIN open
@@ -219,7 +249,7 @@ def main():
     # Only pass the --user option if we're running docker locally/natively.
     # This is to work around a permissions issue in the container when running
     # on OSX using boot2docker.
-    if not 'DOCKER_HOST' in os.environ:
+    if False: # not 'DOCKER_HOST' in os.environ:
         run_args.append('--user={0}:{1}'.format(os.getuid(), os.getgid()))
 
     # Docker image

--- a/src/scuba
+++ b/src/scuba
@@ -172,9 +172,6 @@ def generate_scubainit(config, command):
     with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
         atexit.register(os.remove, f.name)
 
-        # TODO: What if we're not on Linux?
-        os.chmod(f.name, 0777)
-
         def write_cmd(*args):
             f.write(' '.join(c for c in args) + '\n')
 
@@ -211,7 +208,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # top_path is where .scuba.yml is found, and becomes the top of our bind mount
+    # top_path is where .scuba.yml is found, and becomes the top of our bind mount.
     # top_rel is the relative path from top_path to the current working directory,
     # and is where we'll set the working directory in the container (relative to
     # the bind mount point).
@@ -243,18 +240,11 @@ def main():
         '-w', os.path.join(SCUBA_ROOT, top_rel),
     ]
 
-    # Run as the current user:group
-    # Only pass the --user option if we're running docker locally/natively.
-    # This is to work around a permissions issue in the container when running
-    # on OSX using boot2docker.
-    if False: # not 'DOCKER_HOST' in os.environ:
-        run_args.append('--user={0}:{1}'.format(os.getuid(), os.getgid()))
-
     # Docker image
     run_args.append(config['image'])
 
     # Command to run
-    run_args.append('/.scubainit')
+    run_args += ['/bin/sh', '/.scubainit']
 
     #from pprint import pprint; pprint(run_args)
     #sys.exit(42)

--- a/src/scuba
+++ b/src/scuba
@@ -11,6 +11,9 @@ import yaml
 import subprocess
 import shlex
 import argparse
+from tempfile import NamedTemporaryFile
+import atexit
+import pipes
 
 __version__ = '1.2.0'
 
@@ -151,6 +154,24 @@ def make_vol_opt(hostdir, contdir, options=None):
         vol += ':' + ','.join(options)
     return vol
 
+def writeln(f, line):
+    f.write(line + '\n')
+
+def generate_scubainit(config, command):
+    command = process_command(config, command)
+
+    with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
+        #atexit.register(os.remove, f.name)
+
+        # TODO: What if we're not on Linux?
+        os.chmod(f.name, 0777)
+
+        writeln(f, '#!/bin/sh')
+        writeln(f, 'echo "hello from scubainit"')
+        writeln(f, ' '.join(pipes.quote(c) for c in command))
+
+        return f.name
+
 def parse_args():
     ap = argparse.ArgumentParser(description='Simple Container-Utilizing Build Apparatus')
     ap.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)
@@ -170,6 +191,8 @@ def main():
 
     config = load_config(os.path.join(top_path, SCUBA_YML))
 
+    scubainit_path = generate_scubainit(config, args.command)
+
     run_args = ['docker', 'run',
         # interactive: keep STDIN open
         '-i',
@@ -179,6 +202,9 @@ def main():
 
         # remove container after exit
         '--rm',
+
+        # Mount scubainit script
+        make_vol_opt(scubainit_path, '/.scubainit', 'z'),
 
         # Mount build directory...
         # NOTE: This tells Docker to re-label the directory for compatibility
@@ -199,10 +225,11 @@ def main():
     # Docker image
     run_args.append(config['image'])
 
-    run_args += process_command(config, args.command)
+    # Command to run
+    run_args.append('/.scubainit')
 
     #from pprint import pprint; pprint(run_args)
-    #return 42
+    #sys.exit(42)
 
     try:
         rc = subprocess.call(run_args)

--- a/src/scuba
+++ b/src/scuba
@@ -14,6 +14,7 @@ import argparse
 from tempfile import NamedTemporaryFile
 import atexit
 import pipes
+import json
 
 __version__ = '1.2.0'
 
@@ -170,14 +171,49 @@ def shell_quote(s):
     # http://stackoverflow.com/a/847800/119527
     return pipes.quote(s)
 
+def get_image_command(image):
+    '''Gets the default command for an image'''
+    args = ['docker', 'inspect', image]
+    try:
+        p = subprocess.Popen(args, stdout = subprocess.PIPE)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            appmsg('Failed to execute docker. Is it installed?')
+            sys.exit(2)
+    
+    stdout, _ = p.communicate()
+    if not p.returncode == 0:
+        appmsg('Failed to inspect image')
+        sys.exit(2)
+
+    info = json.loads(stdout)[0]
+    return info['Config']['Cmd']
+
+
 def generate_scubainit(config, command):
-    # Expand any aliases
-    command = process_command(config, command)
+    '''Generate a .scubainit script
+
+    This script is executed by /bin/sh, as passed to "docker run".
+    It is responsible for setting up the environment, and running the
+    user-specified command. Normally, if the user provides no command to
+    "docker run", the image's default CMD is run. Because we force
+    "/bin/sh .scubainit" to be run, scuba must emulate the default behavior
+    itself.
+    '''
+
+    if len(command) > 0:
+        # Expand any aliases
+        command = process_command(config, command)
+    else:
+        # No user-provided command; we want to run the image's default command
+        command = get_image_command(config['image'])
 
     # Turn command into a string which you would enter in a shell
     command = ' '.join(shell_quote(c) for c in command)
 
+    # Open a temporary file
     with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
+        # Delete this file when scuba exits
         atexit.register(os.remove, f.name)
 
         def write_cmd(*args):


### PR DESCRIPTION
`.scubainit` is used to perform initial actions in the container, prior to executing the user command.

It's primary purpose at this point is to create `scubauser` inside the container, to fix #11.