### PR TITLE
Add --dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Added `--verbose` option
+- Added `--verbose` and `--dry-run` options
 
 ## [1.3.0] - 2016-01-07
 ### Added

--- a/src/scuba
+++ b/src/scuba
@@ -278,6 +278,7 @@ def generate_scubainit(config, command):
 
 def parse_args():
     ap = argparse.ArgumentParser(description='Simple Container-Utilizing Build Apparatus')
+    ap.add_argument('-n', '--dry-run', action='store_true')
     ap.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)
     ap.add_argument('-V', '--verbose', action='store_true')
     ap.add_argument('command', nargs=argparse.REMAINDER)
@@ -292,7 +293,7 @@ def main():
     args = parse_args()
 
     global cleanup
-    cleanup = FileCleanup()
+    cleanup = FileCleanup(skip=args.dry_run)
 
     # top_path is where .scuba.yml is found, and becomes the top of our bind mount.
     # top_rel is the relative path from top_path to the current working directory,
@@ -370,11 +371,16 @@ def main():
     # Command to run in container
     run_args += docker_cmd
 
-    if g_verbose:
+    if g_verbose or args.dry_run:
         from pprint import pprint
-        verbose_msg('Running Docker:')
+        appmsg('Docker arguments:')
         pprint(run_args)
-    #sys.exit(42)
+
+    if args.dry_run:
+        appmsg('Exiting for dry run. Temporary files not removed:')
+        for f in cleanup.files:
+            print('   ' + f, file=sys.stderr)
+        sys.exit(42)
 
     try:
         rc = subprocess.call(run_args)

--- a/src/scuba
+++ b/src/scuba
@@ -31,6 +31,22 @@ def verbose_msg(fmt, *args):
     if g_verbose:
         appmsg(fmt, *args)
 
+class FileCleanup(object):
+    def __init__(self, skip=False):
+        self.files = []
+        if not skip:
+            atexit.register(self.__cleanup)
+
+    def add(self, path):
+        self.files.append(path)
+
+    def __cleanup(self):
+        for f in self.files:
+            try:
+                os.remove(f)
+            except OSError:
+                pass
+
 
 # http://stackoverflow.com/a/9577670
 class Loader(yaml.Loader):
@@ -221,8 +237,7 @@ def generate_scubainit(config, command):
 
     # Open a temporary file
     with NamedTemporaryFile(prefix='scubainit', delete=False) as f:
-        # Delete this file when scuba exits
-        atexit.register(os.remove, f.name)
+        cleanup.add(f.name)
 
         def write_cmd(*args):
             f.write(' '.join(c for c in args) + '\n')
@@ -275,6 +290,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    global cleanup
+    cleanup = FileCleanup()
 
     # top_path is where .scuba.yml is found, and becomes the top of our bind mount.
     # top_rel is the relative path from top_path to the current working directory,


### PR DESCRIPTION
This adds a `--dry-run` option which complements `--verbose` for debugging / informational purposes.

Specifying `--dry-run` doesn't actually run Docker, and also skips the removal of temporary files, so they can be inspected.

This closes #19.