### PR TITLE
Enable Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ python:
   - "3.5-dev" # 3.5 development branch
   - "nightly" # currently points to 3.6-dev
 
+matrix:
+  allow_failures:
+    - python: "nightly"
+
 install:
   - "pip install -r requirements.txt"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ install:
 
 script:
   - ./run_tests.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+
+install:
+  - "pip install -r requirements.txt"
+
+script:
+  - ./run_tests.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyYAML
 nose
-coverage
+
+# Keep coverage at a lower version to prevent TravisCI failures:
+# https://github.com/travis-ci/travis-ci/issues/4866
+coverage<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML
+nose
+coverage

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-nosetests -v --with-coverage --cover-package=scuba
+nosetests -v --with-coverage --cover-inclusive --cover-package=scuba

--- a/scuba/__init__.py
+++ b/scuba/__init__.py
@@ -1,0 +1,3 @@
+# Importing main ensures it is included in coverage,
+# even though we have no tests covering it yet.
+from . import __main__ as main

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,8 +73,7 @@ class TestConfig(TestCase):
         assert_paths_equal(rel, join(*subdirs))
 
     def test_find_config_nonexist(self):
-        with assert_raises(scuba.config.ConfigError):
-            scuba.config.find_config()
+        assert_raises(scuba.config.ConfigError, scuba.config.find_config)
 
     ######################################################################
     # Load config
@@ -83,8 +82,7 @@ class TestConfig(TestCase):
         with open('.scuba.yml', 'w') as f:
             pass
 
-        with assert_raises(scuba.config.ConfigError):
-            scuba.config.load_config('.scuba.yml')
+        assert_raises(scuba.config.ConfigError, scuba.config.load_config, '.scuba.yml')
 
     def test_load_config_minimal(self):
         with open('.scuba.yml', 'w') as f:
@@ -137,15 +135,13 @@ class TestConfig(TestCase):
         with open('.scuba.yml', 'w') as f:
             f.write('image: !from_yaml .gitlab.yml somewhere.NONEXISTANT\n')
 
-        with assert_raises(scuba.config.ConfigError):
-            scuba.config.load_config('.scuba.yml')
+        assert_raises(scuba.config.ConfigError, scuba.config.load_config, '.scuba.yml')
 
     def test_load_config_image_from_yaml_missing_file(self):
         with open('.scuba.yml', 'w') as f:
             f.write('image: !from_yaml .NONEXISTANT.yml image\n')
 
-        with assert_raises(scuba.config.ConfigError):
-            scuba.config.load_config('.scuba.yml')
+        assert_raises(scuba.config.ConfigError, scuba.config.load_config, '.scuba.yml')
 
     def test_load_config_image_from_yaml_missing_arg(self):
         with open('.gitlab.yml', 'w') as f:
@@ -154,5 +150,4 @@ class TestConfig(TestCase):
         with open('.scuba.yml', 'w') as f:
             f.write('image: !from_yaml .gitlab.yml\n')
 
-        with assert_raises(scuba.config.ConfigError):
-            scuba.config.load_config('.scuba.yml')
+        assert_raises(scuba.config.ConfigError, scuba.config.load_config, '.scuba.yml')


### PR DESCRIPTION
This enables Travis CI builds and Codecov.io coverage reporting.

Note that the tests are still failing on two Python versions:
- Python 2.6, due to some Unicode issue in the custom YAML loader
- Python 3.6.0a0 (nightly), due to some error with `inspect`:
`AttributeError: module 'inspect' has no attribute 'getargspec'`

https://docs.travis-ci.com/user/languages/python