### PR TITLE
Add system test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - docker version
 
 script:
-  - ./run_tests.sh
+  - ./run_nosetests.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_script:
 
 script:
   - ./run_nosetests.sh
+  - sudo pip install .
+  - ./run_full_tests.py
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/run_full_tests.py
+++ b/run_full_tests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import os
+import sys
+import subprocess
+import tempfile
+import shutil
+
+
+class InTempDir(object):
+    def __init__(self, suffix='', prefix='tmp', delete=True):
+        self.delete = delete
+        self.temp_path = tempfile.mkdtemp(suffix=suffix, prefix=prefix)
+
+    def __enter__(self):
+        self.orig_path = os.getcwd()
+        os.chdir(self.temp_path)
+        return self
+
+    def __exit__(self, *exc_info):
+        # Restore the working dir and cleanup the temp one
+        os.chdir(self.orig_path)
+        if self.delete:
+            shutil.rmtree(self.temp_path)
+
+def test1():
+    with InTempDir(prefix='scuba-systest'):
+        with open('.scuba.yml', 'w+t') as f:
+            f.write('image: debian:8.2\n')
+
+        in_data = 'success'
+
+        with open('file.in', 'w+t') as f:
+            f.write(in_data)
+
+        subprocess.check_call(['scuba', '/bin/sh', '-c', 'cat file.in >> file.out'])
+
+        with open('file.out', 'rt') as f:
+            out_data = f.read()
+
+        assert in_data == out_data
+
+def main():
+    test1()
+    print('All is good.')
+
+if __name__ == '__main__':
+    main()

--- a/run_nosetests.sh
+++ b/run_nosetests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+nosetests -v \
+    --with-coverage \
+    --cover-inclusive \
+    --cover-package=scuba \
+    --processes=-1 \
+    --detailed-errors \
+    $@

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-nosetests -v --with-coverage --cover-inclusive --cover-package=scuba $@


### PR DESCRIPTION
This runs `pip install .` to verify that setup.py works and can successfully install scuba. The test script then runs scuba (via process execution, instead of calling it's main), and verifies that basic operations are successful.