### PR TITLE
Better dry run output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Scuba is now a package, and setup.py installs it as such, including an
   auto-generated `console_script` wrapper.
+- `--dry-run` output now shows an actual docker command-line.
 
 ### Fixed
 - Better handle empty `.scuba.yml` and other yaml-related errors

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -20,6 +20,7 @@ from .constants import *
 from .config import find_config, load_config, ConfigError
 from .etcfiles import *
 from .filecleanup import FileCleanup
+from .utils import *
 
 __version__ = '1.4.0'
 
@@ -203,9 +204,8 @@ def main(argv=None):
     run_args += docker_cmd
 
     if g_verbose or args.dry_run:
-        from pprint import pprint
-        appmsg('Docker arguments:')
-        pprint(run_args)
+        appmsg('Docker command line:')
+        print(format_cmdline(run_args))
 
     if args.dry_run:
         appmsg('Exiting for dry run. Temporary files not removed:')

--- a/scuba/utils.py
+++ b/scuba/utils.py
@@ -1,0 +1,15 @@
+try:
+    from shlex import quote as shell_quote
+except ImportError:
+    from pipes import quote as shell_quote
+
+def format_cmdline(args, maxwidth=80):
+    def lines():
+        line = ''
+        for a in (shell_quote(a) for a in args):
+            if len(line) + len(a) > maxwidth:
+                yield line
+                line = ''
+            line += ' ' + a
+
+    return '$' + ' \\\n'.join(lines())


### PR DESCRIPTION
Currently when `--dry-run` is passed, it pretty-prints the docker run args with `pprint`. This change makes scuba print out an actual copy-and-pasteable command line, formatted to look nice as well.