### PR TITLE
Don't pass -t to 'docker run' when stdout is redirected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Scuba is now a package, and setup.py installs it as such, including an
   auto-generated `console_script` wrapper.
 - `--dry-run` output now shows an actual docker command-line.
+- Only pass --tty to docker if scuba's stdout is a TTY.
 
 ### Fixed
 - Better handle empty `.scuba.yml` and other yaml-related errors

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -184,9 +184,6 @@ def main(argv=None):
         # interactive: keep STDIN open
         '-i',
 
-        # allocate TTY
-        '-t',
-
         # remove container after exit
         '--rm',
 
@@ -196,6 +193,10 @@ def main(argv=None):
         # ...and set the working dir relative to it
         '-w', os.path.join(SCUBA_ROOT, top_rel),
     ] + docker_opts
+
+    # allocate TTY if scuba's output is going to a terminal
+    if sys.stdout.isatty():
+        run_args.append('--tty')
 
     # Docker image
     run_args.append(config.image)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,3 +53,13 @@ class BetterAssertRaisesMixin(object):
         else:
             self.fail('"{0}" was expected to throw "{1}" exception'
                           .format(func.__name__, exception_type.__name__))
+
+
+# http://stackoverflow.com/a/8389373/119527
+class PseudoTTY(object):
+    def __init__(self, underlying):
+        self.__underlying = underlying
+    def __getattr__(self, name):
+        return getattr(self.__underlying, name)
+    def isatty(self):
+        return True


### PR DESCRIPTION
This change will only pass `-t` to `docker run` when stdout is a TTY.

This fixes #31.