### PR TITLE
Update setup.py to use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import scuba.version
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name = 'SCUBA',


### PR DESCRIPTION
Whichever boilerplate setup.py was taken from used distutils. Update it to use setuptools so installation works when running setup.py directly, as opposed to via `pip install`.