### PR TITLE
Implement writable home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Switches users then *execs* the user command
   This is to provide more control during initialization, without the artifacts
   caused by the use of 'su' in the .scubainit from 1.3.
+- scubauser now has a proper writable home directory in the container (#45)
 
 ## [1.6.0] - 2016-02-06
 ### Added

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -292,6 +292,11 @@ change_user(void)
         return -1;
     }
 
+    /* Set expected environment variables */
+    setenv("USER", SCUBA_USER, 1);
+    setenv("LOGNAME", SCUBA_USER, 1);
+    setenv("HOME", SCUBA_HOME, 1);
+
     verbose("Changed to uid=%u euid=%u  gid=%u egid=%u\n",
             getuid(), geteuid(), getgid(), getegid());
 

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -467,9 +467,6 @@ process_envvars(void)
     }
 
     /* Clear out other env. vars */
-    unsetenv("USER");
-    unsetenv("HOME");
-    unsetenv("LOGNAME");
     unsetenv("PWD");
     unsetenv("OLDPWD");
     unsetenv("XAUTHORITY");

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -141,7 +141,7 @@ out:
  */
 static int
 add_user(const char *path, const char *name, unsigned int uid, unsigned int gid,
-         const char *gecos)
+         const char *gecos, const char *homedir)
 {
     int result = -1;
     FILE *f = NULL;
@@ -183,7 +183,7 @@ add_user(const char *path, const char *name, unsigned int uid, unsigned int gid,
         .pw_uid     = uid,
         .pw_gid     = gid,
         .pw_gecos   = (char*)gecos,     /* putpwent will not modify */
-        .pw_dir     = "/",          /* Docker sets $HOME=/ */
+        .pw_dir     = (char*)homedir,   /* putpwent will not modify */
         .pw_shell   = "/bin/sh",
     };
 
@@ -498,7 +498,8 @@ main(int argc, char **argv)
         /* Add scuba user and group */
         if (add_group(ETC_GROUP, SCUBA_GROUP, m_gid) != 0)
             exit(99);
-        if (add_user(ETC_PASSWD, SCUBA_USER, m_uid, m_gid, SCUBA_USER_FULLNAME) != 0)
+        if (add_user(ETC_PASSWD, SCUBA_USER, m_uid, m_gid,
+                    SCUBA_USER_FULLNAME, SCUBA_HOME) != 0)
             exit(99);
         if (add_shadow(ETC_SHADOW, SCUBA_USER) != 0)
             exit(99);

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -300,6 +300,26 @@ class TestMain(TestCase):
         assert_equal(username, 'root')
         assert_equal(gid, 0)
         assert_equal(groupname, 'root')
+    
+
+    def _test_home_writable(self, scuba_args=[]):
+        with open('.scuba.yml', 'w') as f:
+            f.write('image: {0}\n'.format(DOCKER_IMAGE))
+
+        args = scuba_args + ['/bin/sh', '-c', 'echo success >> ~/testfile; cat ~/testfile']
+        out, _ = self.run_scuba(args)
+
+        assert_str_equalish(out, 'success')
+
+
+    def test_home_writable_scubauser(self):
+        '''Verify scubauser has a writable homedir'''
+        self._test_home_writable()
+
+
+    def test_home_writable_root(self):
+        '''Verify root has a writable homedir'''
+        self._test_home_writable(['-r'])
 
 
     def test_arbitrary_docker_args(self):


### PR DESCRIPTION
This creates a home directory for the scubauser, and ensures the `HOME`, `USER`, and `LOGNAME` env vars are set properly.

This fixes #45.