### PR TITLE
Improve YAML documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,8 @@ by overriding the `CC` environment variable in step 1:
 
 Configuration is done using a [YAML](http://yaml.org/) file named `.scuba.yml` in the root
 directory of your project. It is expected that `.scuba.yml` be checked in to version control.
-
-Required nodes:
-
-- `image` - The Docker image to run
-
-Optional nodes:
-
-- `aliases` - A dictionary of bash-like aliases
-- `hooks` - "Hooks" that run as part of `scubainit` before running the user command
+Full documentation on [`.scuba.yml`] can be found in [`doc/yaml-reference.md`](doc/yaml-reference.md),
+and specific examples can be found in the [`example`](example/) directory.
 
 An example `.scuba.yml` file might look like this:
 
@@ -65,51 +58,9 @@ image: gcc:5.1
 
 aliases:
   build: make -j4
-
-
-# These hooks run during scubainit
-hooks:
-
-  # The "root" hook runs just before we switch users
-  root:
-    # This uses the complex form, with a 'script' subkey,
-    # which is a list of command strings making up the script.
-    script:
-      - 'echo "HOOK: This runs before we switch users"'
-      - id
-
-  # The "user" hook runs just before we execute the user command.
-  # This uses the simple form, which is just a single command string.
-  user: 'echo "HOOK: After switching users, uid=$(id -u) gid=$(id -g)"'
 ```
-
-This tells SCUBA:
-- Use the `gcc:5.1` Docker image
-- `build` is an alias for `make -j4`.
 
 In this example, `scuba build foo` would execute `make -j4 foo` in a `gcc:5.1` container.
-Prior to running `make`, the hooks would execute, echoing messages about the user ID.
-
-### Extended syntax
-In addition to normal YAML syntax, an additional constructor, `!from_yaml`, is available for `.scuba.yml` which allows a key to be retrieved from an external YAML file. Is has the following syntax:
-```yaml
-!from_yaml filename key
-```
-where `filename` is the path of an external YAML file, and `key` is a dot-separated locator of the key to retrieve.
-
-This is useful for projects where a Docker image in which to build is already specified in another YAML file, for example in [`.gitlab-ci.yml`](http://doc.gitlab.com/ce/ci/yaml/README.html). This eliminates the redundancy between the configuration files. An example which uses this:
-
-**`.gitlab-ci.yml`**
-```yaml
-image: gcc:5.1
-# ...
-```
-
-**`.scuba.yml`**
-```yaml
-image: !from_yaml .gitlab-ci.yml image
-```
-
 
 ## License
 

--- a/doc/yaml-reference.md
+++ b/doc/yaml-reference.md
@@ -1,0 +1,112 @@
+# Scuba YAML File Reference
+
+`.scuba.yml` is a [YAML] file which defines project-specific settings, allowing
+a project to use Scuba as part of manual command-line interaction. As with many
+other YAML file schemas, most options are controlled by top-level keys.
+
+
+
+## Top-level keys
+
+### `image`
+
+The `image` node *is required* and defines the Docker image from which Scuba
+containers are created.
+
+Example:
+```yaml
+image: debian:8.2
+```
+
+### `aliases`
+
+The optional `aliases` node is a mapping (dictionary) of bash-like aliases,
+where each key is an alias, and each value is the command that will be run when
+that alias is specified as the *user command* during scuba invocation. The
+command is parsed like a shell command-line, and additional user arguments from
+the command line are appended to the alias arguments.
+
+Example:
+```yaml
+aliases:
+  build: make -j4
+```
+In this example, `$ scuba build foo` would execute `make -j4 foo` in the
+container.
+
+### `hooks`
+
+The optional `hooks` node is a mapping (dictionary) of "hook" scripts that run
+as part of `scubainit` before running the user command. They use the
+[*common script schema*](#common-script-schema). The following hooks exist:
+- `root` - Runs just before `scubainit` switches from `root` to `scubauser`
+- `user` - Runs just before `scubainit` executes the user command
+
+Example:
+```yaml
+hooks:
+  root:
+    script:
+      - 'echo "HOOK: This runs before we switch users"'
+      - id
+  user: 'echo "HOOK: After switching users, uid=$(id -u) gid=$(id -g)"'
+```
+
+## Common script schema
+Several parts of `.scuba.yml` which define "scripts" use a common schema.
+The *common script schema* can define a "script" in one of two forms:
+
+The *simple* form is simply a single string value:
+```yaml
+hooks:
+  user: echo hello
+```
+
+The *complex* form is a mapping, which must contain a `script` subkey, whose
+value is a list of strings making up the script:
+```yaml
+hooks:
+  root:
+    script:
+      - 'echo hello!'
+      - touch foo
+      - 'echo goodbye :-('
+```
+
+Note that in any case, YAML strings do not need to be enclosed in quotes,
+unless there are "confusing" characters (like a colon). In any case, it is
+always safer to include quotes.
+
+
+## Accessing external YAML content
+In addition to normal [YAML] synax, an additional constructor, `!from_yaml`, is
+available for use in `.scuba.yml` which allows a value to be retrieved from an
+external YAML file. It has the following syntax:
+```yaml
+!from_yaml filename key
+```
+Arguments:
+- **`filename`** - The path of an external YAML file (relative to `.scuba.yaml`)
+- **`key`** - A dot-separated locator of the key to retrieve
+
+This is useful for projects where a Docker image in which to build is already
+specified in another YAML file, for example in [`.gitlab-ci.yml`]. This
+eliminates the redundancy between the configuration files. An example which
+uses this:
+
+**`.gitlab-ci.yml`**
+```yaml
+image: gcc:5.1
+# ...
+```
+
+**`.scuba.yml`**
+```yaml
+image: !from_yaml .gitlab-ci.yml image
+```
+
+
+[YAML]: http://yaml.org/
+[`.gitlab-ci.yml`]: http://doc.gitlab.com/ce/ci/yaml/README.html
+
+


### PR DESCRIPTION
This pulls the `.scuba.yml` reference out into its own document, and leaves only a terse example in the main `README.md`.