### PR TITLE
scuba: Allow .scuba.yml to be absent if --image is given

### DIFF
--- a/scuba/config.py
+++ b/scuba/config.py
@@ -11,6 +11,9 @@ from .constants import *
 class ConfigError(Exception):
     pass
 
+class ConfigNotFoundError(ConfigError):
+    pass
+
 def shlex_split(s):
     # shlex.split doesn't properly handle unicode input in Python 2.6.
     # First try to encode it as an ASCII string. which
@@ -92,12 +95,12 @@ def find_config():
         if not cross_fs and os.path.ismount(path):
             msg = '{0} not found here or any parent up to mount point {1}'.format(SCUBA_YML, path) \
                    + '\nStopping at filesystem boundary (SCUBA_DISCOVERY_ACROSS_FILESYSTEM not set).'
-            raise ConfigError(msg)
+            raise ConfigNotFoundError(msg)
 
         # Traverse up directory hierarchy
         path, rest = os.path.split(path)
         if not rest:
-            raise ConfigError('{0} not found here or any parent directories'.format(SCUBA_YML))
+            raise ConfigNotFoundError('{0} not found here or any parent directories'.format(SCUBA_YML))
 
         # Accumulate the relative path back to where we started
         rel = os.path.join(rest, rel)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -396,6 +396,20 @@ class TestMain(TestCase):
         out, _ = self.run_scuba(args)
         assert_str_equalish('multi\nline\nalias', out)
 
+    def test_yml_not_needed_with_image_override(self):
+        '''Verify .scuba.yml can be missing if --image is used'''
+
+        # no .scuba.yml
+
+        test_string = 'Hello world'
+        args = [
+            # This image was built with ENTRYPOINT ["echo"]
+            '--image', 'jreinhart/echo',
+            test_string,
+        ]
+        out, _ = self.run_scuba(args)
+        assert_str_equalish(test_string, out)
+
 
     ############################################################################
     # Hooks


### PR DESCRIPTION
If --image is given, then .scuba.yml is allowed to be absent. In this
case, the project top directory will simply be defined as the current
directory (as Scuba cannot know where the "top" of your project is).

Closes #90