### PR TITLE
Do not detect as a remote run if DOCKER_HOST is set to a unix:// socket

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -148,7 +148,10 @@ class ScubaDive(object):
 
     @property
     def is_remote_docker(self):
-        return 'DOCKER_HOST' in os.environ
+        if 'DOCKER_HOST' in os.environ:
+            if not os.environ['DOCKER_HOST'].startswith('unix://'):
+                return True
+        return False
 
     def add_env(self, name, val):
         '''Add an environment variable to the docker run invocation


### PR DESCRIPTION
Certain use cases set DOCKER_HOST even if it points to a local docker instance. So a simple check if the variable is set is insufficient in some cases. Adding a check for if the variable is set to something using the unix:// protocol will make this filter more exact. 