### PR TITLE
Fix script mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Display nicer error message if no command is given and image doesn't specify a `Cmd` (#104)
+- Don't mangle && in scripts (#100)
 
 ## [2.1.0] - 2017-04-03
 ### Added

--- a/example/alias_multiline/.scuba.yml
+++ b/example/alias_multiline/.scuba.yml
@@ -5,5 +5,4 @@ aliases:
   complex:
     script:
       - echo 'this is a complex script'
-      - date
-      - uname -a
+      - date && uname -a

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -266,7 +266,7 @@ class ScubaDive(object):
             if not default_cmd:
                 raise ScubaError('No command given and no image-specified command')
             verbose_msg('{0} Cmd: "{1}"'.format(context.image, default_cmd))
-            context.script = [default_cmd]
+            context.script = [shell_quote_cmd(default_cmd)]
 
         # Make scubainit the entrypoint, and manually insert an existing
         # entrypoint before each user command
@@ -280,8 +280,9 @@ class ScubaDive(object):
             writeln(f, '# Auto-generated from scuba')
             writeln(f, 'set -e')
             for cmd in context.script:
-                cmd = entrypoint + cmd
-                writeln(f, shell_quote_cmd(cmd))
+                if entrypoint:
+                    cmd = shell_quote_cmd(entrypoint) + ' ' + cmd
+                writeln(f, cmd)
 
         self.context = context
 

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import yaml
 import shlex
@@ -133,7 +134,7 @@ class ScubaAlias(object):
 
     @classmethod
     def from_dict(cls, name, node):
-        script = [shlex_split(cmd) for cmd in _process_script_node(node, name)]
+        script = _process_script_node(node, name)
         image = node.get('image') if isinstance(node, dict) else None
         return cls(name, script, image)
 
@@ -204,7 +205,7 @@ class ScubaConfig(object):
             command     A user command list (e.g. argv)
 
         Returns: A ScubaContext object with the following attributes:
-            script: a list of command lists
+            script: a list of command line strings
             image: the docker image name to use
         '''
         result = ScubaContext()
@@ -215,7 +216,7 @@ class ScubaConfig(object):
             alias = self.aliases.get(command[0])
             if not alias:
                 # Command is not an alias; use it as-is.
-                result.script = [command]
+                result.script = [shell_quote_cmd(command)]
             else:
                 # Using an alias
                 # Does this alias override the image?
@@ -233,7 +234,7 @@ class ScubaConfig(object):
                     # Alias is a single-line script; perform substituion
                     # and add user arguments.
                     command.pop(0)
-                    result.script = [alias.script[0] + command]
+                    result.script = [alias.script[0] + ' ' + shell_quote_cmd(command)]
 
         return result
 

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -7,19 +7,13 @@ except NameError:
     basestring = str    # Python 3
 
 from .constants import *
+from .utils import *
 
 class ConfigError(Exception):
     pass
 
 class ConfigNotFoundError(ConfigError):
     pass
-
-def shlex_split(s):
-    # shlex.split doesn't properly handle unicode input in Python 2.6.
-    # First try to encode it as an ASCII string. which
-    # may raise a UnicodeEncodeError.
-    s = str(s)
-    return shlex.split(s)
 
 # http://stackoverflow.com/a/9577670
 class Loader(yaml.Loader):

--- a/scuba/utils.py
+++ b/scuba/utils.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import shlex
 try:
     from shlex import quote as shell_quote
 except ImportError:
@@ -8,6 +9,13 @@ except ImportError:
 
 def shell_quote_cmd(cmdlist):
     return ' '.join(map(shell_quote, cmdlist))
+
+def shlex_split(s):
+    # shlex.split doesn't properly handle unicode input in Python 2.6.
+    # First try to encode it as an ASCII string. which
+    # may raise a UnicodeEncodeError.
+    s = str(s)
+    return shlex.split(s)
 
 
 def format_cmdline(args, maxwidth=80):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -419,6 +419,22 @@ class TestMain(TestCase):
         out, _ = self.run_scuba(args)
         assert_str_equalish(test_string, out)
 
+    def test_complex_commands_in_alias(self):
+        '''Verify complex commands can be used in alias scripts'''
+        test_string = 'Hello world'
+        os.mkdir('foo')
+        with open('foo/bar.txt', 'w') as f:
+            f.write(test_string)
+        with open('.scuba.yml', 'w') as f:
+            f.write('image: {0}\n'.format(DOCKER_IMAGE))
+            f.write('aliases:\n')
+            f.write('  alias1:\n')
+            f.write('    script:\n')
+            f.write('      - cd foo && cat bar.txt\n')
+
+        out, _ = self.run_scuba(['alias1'])
+        assert_str_equalish(test_string, out)
+
 
     ############################################################################
     # Hooks


### PR DESCRIPTION
This prevents scuba from mangling constructs like && in scripts.

Doing so required re-doing all of the script parsing logic, treating scripts as lists of full command-line strings, instead of lists of parsed command-line lists.

Fixes #100