### PR TITLE
Update scuba to work on Windows Subsystem for Linux

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -13,6 +13,7 @@ import tempfile
 import shutil
 import platform
 import re
+import random
 
 from .cmdlineargs import *
 from .compat import File, StringIO
@@ -215,7 +216,8 @@ class ScubaDive(object):
         '''Make temp directory where all ancillary files are bind-mounted
         '''
         if self.__os_type == 'WSL':
-            scuba_dir_path = os.path.join(self.__wsl_path, 'tmp/scubadir/')
+            rand = random.randint(10000, 99999)
+            scuba_dir_path = os.path.join(self.__wsl_path, 'tmp/scubadir' + str(rand))
             if not os.path.exists(scuba_dir_path):
                 os.makedirs(scuba_dir_path)
         else:


### PR DESCRIPTION
The reason scuba previously didn't work with WSL is two part, WSL must
connect to docker remotely, and the file paths that must be supplied
for WSL to work with docker is different than conventional Linux file
paths, as well as the file paths used by scuba. By having scuba check if
it is running from within WSL it is able to verify that the proper paths
are set up (Typically by mounting C:\ as /c/) and that the files needed
to run (scubainit and the temp directory) are placed in a location that
Windows is able to find (C:\ProgramData\Scuba or /c/ProgramData/Scuba in
WSL). These changes allow scuba to run on WSL which is connecting to
Docker remotely.