### PR TITLE
Build local docker images

### DIFF
--- a/ci/test_setup.sh
+++ b/ci/test_setup.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+set -e
+
+topdir=$(cd $(dirname $0)/.. && pwd)
 
 # Pull this image ahead of time, so it's there for the unit tests
 docker pull debian:8.2
+
+# Build docker images for local testing
+$topdir/test-docker-images/build_all.sh

--- a/test-docker-images/build_all.sh
+++ b/test-docker-images/build_all.sh
@@ -3,3 +3,4 @@ set -e
 cd $(dirname $0)
 
 entrypoint-test/build.sh
+hello/build.sh

--- a/test-docker-images/build_all.sh
+++ b/test-docker-images/build_all.sh
@@ -4,3 +4,4 @@ cd $(dirname $0)
 
 entrypoint-test/build.sh
 hello/build.sh
+scratch/build.sh

--- a/test-docker-images/build_all.sh
+++ b/test-docker-images/build_all.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+cd $(dirname $0)
+

--- a/test-docker-images/entrypoint-test/Dockerfile
+++ b/test-docker-images/entrypoint-test/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test-docker-images/entrypoint-test/build.sh
+++ b/test-docker-images/entrypoint-test/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+image="scuba/entrypoint-test"
+cd $(dirname $0)
+docker build -t $image .
+echo "Built $image"

--- a/test-docker-images/entrypoint-test/entrypoint.sh
+++ b/test-docker-images/entrypoint-test/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export ENTRYPOINT_WORKS=success
+echo 'success' > entrypoint_works.txt
+exec "$@"

--- a/test-docker-images/hello/Dockerfile
+++ b/test-docker-images/hello/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+ADD hello.sh /hello.sh
+CMD ["/hello.sh"]

--- a/test-docker-images/hello/build.sh
+++ b/test-docker-images/hello/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+image="scuba/hello"
+cd $(dirname $0)
+docker build -t $image .
+echo "Built $image"

--- a/test-docker-images/hello/hello.sh
+++ b/test-docker-images/hello/hello.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Hello world"

--- a/test-docker-images/scratch/Dockerfile
+++ b/test-docker-images/scratch/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# 'docker build' complains if we don't do *something*
+ADD Dockerfile /

--- a/test-docker-images/scratch/build.sh
+++ b/test-docker-images/scratch/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+image="scuba/scratch"
+cd $(dirname $0)
+docker build -t $image .
+echo "Built $image"

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -e
 cd $(dirname $0)
-
 entrypoint-test/build.sh

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -2,3 +2,4 @@
 set -e
 cd $(dirname $0)
 entrypoint-test/build.sh
+hello/build.sh

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -3,3 +3,4 @@ set -e
 cd $(dirname $0)
 entrypoint-test/build.sh
 hello/build.sh
+scratch/build.sh

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -49,9 +49,9 @@ class TestDockerutil(TestCase):
 
     def test_get_image_entrypoint(self):
         '''get_image_entrypoint works'''
-        result = uut.get_image_entrypoint('jreinhart/echo')
+        result = uut.get_image_entrypoint('scuba/entrypoint-test')
         self.assertEqual(1, len(result))
-        assert_str_equalish('echo', result[0])
+        assert_str_equalish('/entrypoint.sh', result[0])
 
     def test_get_image_entrypoint__none(self):
         '''get_image_entrypoint works for image with no entrypoint'''

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -362,12 +362,11 @@ class TestMain(TmpDirTestCase):
         '''Verify scuba doesn't interfere with the configured image ENTRYPOINT'''
 
         with open('.scuba.yml', 'w') as f:
-            # This image was built with ENTRYPOINT ["echo"]
-            f.write('image: jreinhart/echo')
+            f.write('image: scuba/entrypoint-test')
 
-        test_string = 'Hello world'
-        out, _ = self.run_scuba([test_string])
-        assert_str_equalish(test_string, out)
+        out, _ = self.run_scuba(['cat', 'entrypoint_works.txt'])
+        assert_str_equalish('success', out)
+
 
     def test_image_override(self):
         '''Verify --image works'''

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,7 +114,7 @@ class TestMain(TmpDirTestCase):
         '''Verify scuba gracefully handles an image with no Cmd and no user command'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format('jreinhart/scratch'))
+            f.write('image: {}\n'.format('scuba/scratch'))
 
         # ScubaError -> exit(128)
         out, _ = self.run_scuba([], 128)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,10 +105,10 @@ class TestMain(TmpDirTestCase):
         '''Verify scuba works with no given command'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format('jreinhart/hello'))
+            f.write('image: {}\n'.format('scuba/hello'))
 
         out, _ = self.run_scuba([])
-        self.assertTrue('Hello from alpine-hello' in out)
+        self.assertTrue('Hello world' in out)
 
     def test_no_image_cmd(self):
         '''Verify scuba gracefully handles an image with no Cmd and no user command'''

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -373,16 +373,14 @@ class TestMain(TmpDirTestCase):
 
         with open('.scuba.yml', 'w') as f:
             # This image does not exist
-            f.write('image: jreinhart/notheredoesnotexistbb7e344f9722\n')
+            f.write('image: scuba/notheredoesnotexistbb7e344f9722\n')
 
-        test_string = 'Hello world'
         args = [
-            # This image was built with ENTRYPOINT ["echo"]
-            '--image', 'jreinhart/echo',
-            test_string,
+            '--image', 'scuba/entrypoint-test',
+            'cat', 'entrypoint_works.txt',
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish(test_string, out)
+        assert_str_equalish('success', out)
 
     def test_image_override_with_alias(self):
         '''Verify --image works with aliases'''
@@ -390,10 +388,10 @@ class TestMain(TmpDirTestCase):
         with open('.scuba.yml', 'w') as f:
             # These images do not exist
             f.write('''
-                image: jreinhart/notheredoesnotexistbb7e344f9722
+                image: scuba/notheredoesnotexistbb7e344f9722
                 aliases:
                   testalias:
-                    image: jreinhart/notheredoesnotexist765205d09dea
+                    image: scuba/notheredoesnotexist765205d09dea
                     script:
                       - echo multi
                       - echo line
@@ -412,14 +410,12 @@ class TestMain(TmpDirTestCase):
 
         # no .scuba.yml
 
-        test_string = 'Hello world'
         args = [
-            # This image was built with ENTRYPOINT ["echo"]
-            '--image', 'jreinhart/echo',
-            test_string,
+            '--image', 'scuba/entrypoint-test',
+            'cat', 'entrypoint_works.txt',
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish(test_string, out)
+        assert_str_equalish('success', out)
 
     def test_complex_commands_in_alias(self):
         '''Verify complex commands can be used in alias scripts'''


### PR DESCRIPTION
Rather than relying on external docker images for testing, build these simple images right from the scuba repository.