### PR TITLE
Enable scuba to override entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Enable scuba to override entrypoint via `--entrypoint` or `.scuba.yml` (#125)
+
 ### Changed
 - Don't run image entrypoint for each line in a mult-line alias (#121)
 

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -298,9 +298,17 @@ class ScubaDive(object):
         # the docker command (if it exists)
         self.add_option('--entrypoint={}'.format(scubainit_cpath))
 
+        # TODO: De-deuplicate the "None vs. empty-string" logic
         if self.entrypoint_override is not None:
+            # --entrypoint takes precedence
             if self.entrypoint_override != '':
                 self.docker_cmd = [self.entrypoint_override]
+            else:
+                self.docker_cmd = []
+        elif context.entrypoint is not None:
+            # then .scuba.yml
+            if context.entrypoint != '':
+                self.docker_cmd = [context.entrypoint]
             else:
                 self.docker_cmd = []
         else:

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -298,21 +298,19 @@ class ScubaDive(object):
         # the docker command (if it exists)
         self.add_option('--entrypoint={}'.format(scubainit_cpath))
 
-        # TODO: De-deuplicate the "None vs. empty-string" logic
+        self.docker_cmd = []
         if self.entrypoint_override is not None:
             # --entrypoint takes precedence
             if self.entrypoint_override != '':
                 self.docker_cmd = [self.entrypoint_override]
-            else:
-                self.docker_cmd = []
         elif context.entrypoint is not None:
             # then .scuba.yml
             if context.entrypoint != '':
                 self.docker_cmd = [context.entrypoint]
-            else:
-                self.docker_cmd = []
         else:
-            self.docker_cmd = get_image_entrypoint(context.image) or []
+            ep = get_image_entrypoint(context.image)
+            if ep:
+                self.docker_cmd = ep
 
         # The user command is executed via a generated shell script
         with self.open_scubadir_file('command.sh', 'wt') as f:

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -151,6 +151,30 @@ def _process_environment(node, name):
 
     return result
 
+def _get_entrypoint(data):
+    # N.B. We can't use data.get() here, because that might return
+    # None, leading to ambiguity between entrypoint being absent or set
+    # to a null value.
+    #
+    # "Note that a null is different from an empty string and that a
+    # mapping entry with some key and a null value is valid and
+    # different from not having that key in the mapping."
+    #   - http://yaml.org/type/null.html
+    key = 'entrypoint'
+
+    if not key in data:
+        return None
+
+    ep = data[key]
+
+    # We represent a null value as an empty string.
+    if ep is None:
+        ep = ''
+
+    if not isinstance(ep, basestring):
+        raise ConfigError("'{}' must be a string, not {}".format(
+                key, type(ep).__name__))
+    return ep
 
 
 class ScubaAlias(object):
@@ -180,7 +204,7 @@ class ScubaContext(object):
 class ScubaConfig(object):
     def __init__(self, **data):
         required_nodes = ('image',)
-        optional_nodes = ('aliases','hooks','environment')
+        optional_nodes = ('aliases','hooks','entrypoint','environment')
 
         # Check for missing required nodes
         missing = [n for n in required_nodes if not n in data]
@@ -195,7 +219,7 @@ class ScubaConfig(object):
                     's' if len(extra) > 1 else '', ', '.join(extra)))
 
         self._image = data['image']
-
+        self._entrypoint = _get_entrypoint(data)
         self._load_aliases(data)
         self._load_hooks(data)
         self._environment = self._load_environment(data)
@@ -230,6 +254,10 @@ class ScubaConfig(object):
         return self._image
 
     @property
+    def entrypoint(self):
+        return self._entrypoint
+
+    @property
     def aliases(self):
         return self._aliases
 
@@ -255,6 +283,7 @@ class ScubaConfig(object):
         result = ScubaContext()
         result.script = None
         result.image = self.image
+        result.entrypoint = self.entrypoint
         result.environment = self.environment.copy()
 
         if command:

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -619,6 +619,6 @@ main(int argc, char **argv)
     verbose("execvp(\"%s\", ...)\n", new_argv[0]);
     execvp(new_argv[0], new_argv);
 
-    errmsg("execv() failed: %m\n");
+    errmsg("execvp(\"%s\", ...) failed: %m\n", new_argv[0]);
     exit(99);
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,6 +216,19 @@ class TestConfig(TmpDirTestCase):
     ######################################################################
     # process_command
 
+    def test_process_command_image(self):
+        '''process_command returns the image and entrypoint'''
+        image_name = 'test_image'
+        entrypoint = 'test_entrypoint'
+
+        cfg = scuba.config.ScubaConfig(
+                image = image_name,
+                entrypoint = entrypoint,
+                )
+        result = cfg.process_command([])
+        assert_equal(result.image, image_name)
+        assert_equal(result.entrypoint, entrypoint)
+
     def test_process_command_empty(self):
         '''process_command handles no aliases and an empty command'''
         cfg = scuba.config.ScubaConfig(
@@ -479,3 +492,50 @@ class TestConfig(TmpDirTestCase):
                 BAR = "42",
                 MORE = "Hello world",
             ))
+
+
+    ############################################################################
+    # Entrypoint
+
+    def test_entrypoint_not_set(self):
+        '''Entrypoint can be missing'''
+        with open('.scuba.yml', 'w') as f:
+            f.write(r'''
+                image: na
+                ''')
+
+        config = scuba.config.load_config('.scuba.yml')
+        self.assertIsNone(config.entrypoint)
+
+    def test_entrypoint_null(self):
+        '''Entrypoint can be set to null'''
+        with open('.scuba.yml', 'w') as f:
+            f.write(r'''
+                image: na
+                entrypoint:
+                ''')
+
+        config = scuba.config.load_config('.scuba.yml')
+        self.assertEqual(config.entrypoint, '')     # Null => empty string
+
+    def test_entrypoint_emptry_string(self):
+        '''Entrypoint can be set to an empty string'''
+        with open('.scuba.yml', 'w') as f:
+            f.write(r'''
+                image: na
+                entrypoint: ""
+                ''')
+
+        config = scuba.config.load_config('.scuba.yml')
+        self.assertEqual(config.entrypoint, '')
+
+    def test_entrypoint_set(self):
+        '''Entrypoint can be set'''
+        with open('.scuba.yml', 'w') as f:
+            f.write(r'''
+                image: na
+                entrypoint: my_ep
+                ''')
+
+        config = scuba.config.load_config('.scuba.yml')
+        self.assertEqual(config.entrypoint, 'my_ep')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -358,6 +358,9 @@ class TestMain(TmpDirTestCase):
         assert_str_equalish(out, data)
 
 
+    ############################################################################
+    # Entrypoint
+
     def test_image_entrypoint(self):
         '''Verify scuba doesn't interfere with the configured image ENTRYPOINT'''
 
@@ -383,6 +386,58 @@ class TestMain(TmpDirTestCase):
         out, _ = self.run_scuba(['testalias'])
         assert_str_equalish('\n'.join(['success']*2), out)
 
+
+    def test_entrypoint_override(self):
+        '''Verify --entrypoint override works'''
+        with open('.scuba.yml', 'w') as f:
+            f.write('''
+                image: scuba/entrypoint-test
+                aliases:
+                  testalias:
+                    script:
+                      - echo $ENTRYPOINT_WORKS
+                ''')
+
+        test_str = 'This is output from the overridden entrypoint'
+
+        with open('new.sh', 'w') as f:
+            f.write('#!/bin/sh\n')
+            f.write('echo "{}"\n'.format(test_str))
+        make_executable('new.sh')
+
+        args = [
+            '--entrypoint', os.path.abspath('new.sh'),
+            'true',
+        ]
+        out, _ = self.run_scuba(args)
+        assert_str_equalish(test_str, out)
+
+
+    def test_entrypoint_override_none(self):
+        '''Verify --entrypoint override (to nothing) works'''
+        with open('.scuba.yml', 'w') as f:
+            f.write('''
+                image: scuba/entrypoint-test
+                aliases:
+                  testalias:
+                    script:
+                      - echo $ENTRYPOINT_WORKS
+                ''')
+
+        args = [
+            '--entrypoint', '',
+            'testalias',
+        ]
+        out, _ = self.run_scuba(args)
+
+        # Verify that ENTRYPOINT_WORKS wasn not set by the entrypoint
+        # (because it didn't run)
+        self.assertNotIn('success', out)
+
+
+
+    ############################################################################
+    # Image override
 
     def test_image_override(self):
         '''Verify --image works'''


### PR DESCRIPTION
This enables Scuba to override the image's configured `ENTRYPOINT`, via either the `--entrypoint` command-line argument, or via an `entrypoint` key in `.scuba.yml`.

Fixes #113 
