### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "nightly" # currently points to 3.6-dev
+  - "3.7"
+  - "nightly"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-# We need sudo, in order to install and run Docker.
-sudo: required
 services:
   - docker
+dist: xenial
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,31 +44,32 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 
-deploy:
-  # See this blog post for an excellent description
-  # https://www.appneta.com/blog/pypi-deployment-with-travis-ci/
+jobs:
+  include:
+    - stage: deploy
+      python: 3.6
+      script: echo "Deploying to PyPI..."
+      deploy:
 
-  # Test PyPI (on any push to master)
-  - provider: pypi
-    server: https://test.pypi.org/legacy/
-    user: jreinhart
-    password:
-      secure: "BYbUHbV3G2lsvDDR9LrYCRFz/g+LAI/pmfa+d+KMlXbY+s7v+pYsENRmwVbhpc1oDSn0UnKgJyc3ZyGAEkmlV0Cog9YxWnoVQgmsT321jIuQur1SjeQ70mgkwS3fRh1hdzrfKkJ3SghFfFyrXzK1kyn8TzDBg7sSyymep2MgO+kRsYxIKP2e8GCTPLmXhifxAPDQZ6rDtRCl4fDgSoakLNsaHQPeaEgEN7E4699edce0lWN2g+2w3NGAmO6jdx3Ly64XX6MoM47/Pjdmi/xncqAqVQ37CCTIM2HRNClujy35KVnTOpjN0ZSsPuCYfx0aIOBzR3cCo7II2VBziQhQ09o1gJOEnd/q2/4rUoaa9Plu1SeO0yQxvjtBS+7iSDnZEDzqQvah/XidZzv6efmvNrme5ueTGnFUt+v4bq03Nu661Jat9FbaDb8NCi1qhnUG+ebJ4t3EIXqd4vIdu6M+1RdNqU5Wmf4j6IUutrjnF8qOexG0hh/MkdiSO6o+cEbltiMhr+Z+F6Y7j9snsqqYvnZ42mjf7KNKfX56/hfi8do2Z9Lb3V9xTHqiL9reRPQdq5s+iXmC75/Ca9rZv6UtNRPt56FdBtEEWGuFcbenZRk/av2baX/MFbqGZbToQ0KbiDcDQNKZGNeaH6+6YfSvjhmFUtM/duhmQaCfcXjhoZA="      
-    distributions: "sdist bdist_wheel"
-    on:
-      branch: master
-      tags: false
-      repo: JonathonReinhart/scuba
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
-  
-  # Production PyPI (only on tags)
-  - provider: pypi
-    user: jreinhart
-    password:
-      secure: "kbjV+UQNXYZbW3jGMaEvK4wYUorVMyrzn5fdVqKmTMLVB6Rl/MwABi5O8ciVHf0bAZzi1xuGud399zLEMWG0P5fYE5UfJplRTg22p/urwZ7OoLQGgD8v5QcOfyyPOGxriapE0I05VdrVi1MUeD6mwQLVOnrVPOSBW/PWvgguyyW9tqWkHCo7flhx8Me5EgD3+39d9027Uaw8IGZFvwCiB6xghOJn8vr2ADhGA/yZtx674UOkmiVMrh7eFLnbSHxiWemTCsf1UiqKF7UyQ7Z6j5qTno+HWPX++Z8nsAdma48jYJQt6OIfXgz8TIStuJxzile5l67TqEZ8QNN7bjggkUKSMSS+v91E0fkc35saGZqKIXQ1Mj3xDgCk91kyaahNfo+pnrxb/wyc/3PaXkTnm517v/b8J6tUR583pYnNcfhiPQWnNGCYI3T0I2JSAvVaCMc3ab0B9jSxia5maiL9AtuPNHa1aB97hgTxQHYazCd8a7X0Bnvl/eiFsr9XQudDM8AG2U8wvKmbf/MCZlMMvptD7UNP1KXEhoUih4XtOKnYeCrpgW9ID83RSae6ClqtQBxTZlRoh9nzxBQMa6NbM3+I6cpDUgfP3oMzMrqaJ38eVlgT7ReFUcfNVb7MworCkca1lNKPLNo1zib0+sWwqbqLSTwP/7+gW5EGkO1fPzU="
-    distributions: "sdist bdist_wheel"
-    on:
-      branch: master
-      tags: true
-      repo: JonathonReinhart/scuba
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
+        # Test PyPI (on any push to master)
+        - provider: pypi
+          server: https://test.pypi.org/legacy/
+          user: jreinhart
+          password:
+            secure: "BYbUHbV3G2lsvDDR9LrYCRFz/g+LAI/pmfa+d+KMlXbY+s7v+pYsENRmwVbhpc1oDSn0UnKgJyc3ZyGAEkmlV0Cog9YxWnoVQgmsT321jIuQur1SjeQ70mgkwS3fRh1hdzrfKkJ3SghFfFyrXzK1kyn8TzDBg7sSyymep2MgO+kRsYxIKP2e8GCTPLmXhifxAPDQZ6rDtRCl4fDgSoakLNsaHQPeaEgEN7E4699edce0lWN2g+2w3NGAmO6jdx3Ly64XX6MoM47/Pjdmi/xncqAqVQ37CCTIM2HRNClujy35KVnTOpjN0ZSsPuCYfx0aIOBzR3cCo7II2VBziQhQ09o1gJOEnd/q2/4rUoaa9Plu1SeO0yQxvjtBS+7iSDnZEDzqQvah/XidZzv6efmvNrme5ueTGnFUt+v4bq03Nu661Jat9FbaDb8NCi1qhnUG+ebJ4t3EIXqd4vIdu6M+1RdNqU5Wmf4j6IUutrjnF8qOexG0hh/MkdiSO6o+cEbltiMhr+Z+F6Y7j9snsqqYvnZ42mjf7KNKfX56/hfi8do2Z9Lb3V9xTHqiL9reRPQdq5s+iXmC75/Ca9rZv6UtNRPt56FdBtEEWGuFcbenZRk/av2baX/MFbqGZbToQ0KbiDcDQNKZGNeaH6+6YfSvjhmFUtM/duhmQaCfcXjhoZA="      
+          distributions: "sdist bdist_wheel"
+          on:
+            branch: master
+            tags: false
+            repo: JonathonReinhart/scuba
+
+        # Production PyPI (only on tags)
+        - provider: pypi
+          user: jreinhart
+          password:
+            secure: "kbjV+UQNXYZbW3jGMaEvK4wYUorVMyrzn5fdVqKmTMLVB6Rl/MwABi5O8ciVHf0bAZzi1xuGud399zLEMWG0P5fYE5UfJplRTg22p/urwZ7OoLQGgD8v5QcOfyyPOGxriapE0I05VdrVi1MUeD6mwQLVOnrVPOSBW/PWvgguyyW9tqWkHCo7flhx8Me5EgD3+39d9027Uaw8IGZFvwCiB6xghOJn8vr2ADhGA/yZtx674UOkmiVMrh7eFLnbSHxiWemTCsf1UiqKF7UyQ7Z6j5qTno+HWPX++Z8nsAdma48jYJQt6OIfXgz8TIStuJxzile5l67TqEZ8QNN7bjggkUKSMSS+v91E0fkc35saGZqKIXQ1Mj3xDgCk91kyaahNfo+pnrxb/wyc/3PaXkTnm517v/b8J6tUR583pYnNcfhiPQWnNGCYI3T0I2JSAvVaCMc3ab0B9jSxia5maiL9AtuPNHa1aB97hgTxQHYazCd8a7X0Bnvl/eiFsr9XQudDM8AG2U8wvKmbf/MCZlMMvptD7UNP1KXEhoUih4XtOKnYeCrpgW9ID83RSae6ClqtQBxTZlRoh9nzxBQMa6NbM3+I6cpDUgfP3oMzMrqaJ38eVlgT7ReFUcfNVb7MworCkca1lNKPLNo1zib0+sWwqbqLSTwP/7+gW5EGkO1fPzU="
+          distributions: "sdist bdist_wheel"
+          on:
+            branch: master
+            tags: true
+            repo: JonathonReinhart/scuba


### PR DESCRIPTION
- Switch to [Xenial](https://docs.travis-ci.com/user/reference/xenial/)
- Remove support for Python 3.3
- Add support for [Python 3.7](https://docs.travis-ci.com/user/reference/xenial/#python-support)
- Use a separate deploy stage for deploying to PyPI