### PR TITLE
Ignore already existing UID/GIDs

### DIFF
--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -103,8 +103,7 @@ add_group(const char *path, const char *name, unsigned int gid)
         }
 
         if (gr->gr_gid == gid) {
-            errmsg("GID %u already exists in %s\n", gid, path);
-            goto out;
+            errmsg("Warning: GID %u already exists in %s\n", gid, path);
         }
     }
 
@@ -175,8 +174,7 @@ add_user(const char *path, const char *name, unsigned int uid, unsigned int gid,
         }
 
         if (pw->pw_uid == uid) {
-            errmsg("UID %u already exists in %s\n", uid, path);
-            goto out;
+            errmsg("Warning: UID %u already exists in %s\n", uid, path);
         }
     }
 


### PR DESCRIPTION
When trying to run a `node` container like so...

```yaml
image: none

aliases:
    yarn:
        image: node:12-alpine
        script: yarn install
```

... I ran into the error message `scubainit: GID 1000 already exists in /etc/group`.

I guess the problem is that I am running locally as UID 1000, but the `node` packages also come with a `node` user with that UID by default (see https://github.com/nodejs/docker-node/issues/289).

I think we could safely proceed in this case; Linux should be able to deal with multiple `/etc/passwd` (and `/etc/group`, FWIW) entries pointing to the same numerical ID.

Not sure if this solves #109, though.
