### PR TITLE
Use calling username/groupname instead of 'scubauser'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Use username/groupname of invoking user inside container (#153)
+
+
 ## [2.4.2] - 2020-02-24
 ### Changed
 - Use GitHub Actions instead of Travis CI for publishing releases

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -4,6 +4,8 @@
 
 from __future__ import print_function
 import os, os.path
+from pwd import getpwuid
+from grp import getgrgid
 import errno
 import sys
 import shlex
@@ -252,8 +254,12 @@ class ScubaDive(object):
         self.add_env('SCUBAINIT_UMASK', '{:04o}'.format(get_umask()))
 
         if not self.as_root:
-            self.add_env('SCUBAINIT_UID', os.getuid())
-            self.add_env('SCUBAINIT_GID', os.getgid())
+            uid = os.getuid()
+            gid = os.getgid()
+            self.add_env('SCUBAINIT_UID', uid)
+            self.add_env('SCUBAINIT_GID', gid)
+            self.add_env('SCUBAINIT_USER', getpwuid(uid).pw_name)
+            self.add_env('SCUBAINIT_GROUP', getgrgid(gid).gr_name)
 
         if self.verbose:
             self.add_env('SCUBAINIT_VERBOSE', 1)

--- a/scuba/constants.py
+++ b/scuba/constants.py
@@ -1,7 +1,2 @@
 # Name of config file to search for and load
 SCUBA_YML = '.scuba.yml'
-
-# User and group name representing the current
-# user, inside the container
-SCUBA_USER = 'scubauser'
-SCUBA_GROUP = SCUBA_USER

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -365,6 +365,19 @@ mkdir_p(const char *path)
 static int
 make_homedir(const char *path, unsigned int uid, unsigned int gid)
 {
+    struct stat st;
+
+    /* See if the home directory already exists */
+    if (stat(path, &st) == 0) {
+        verbose("Homedir %s already exists\n", path);
+        return 0;
+    }
+    else if (errno != ENOENT) {
+        errmsg("Failed to stat %s: %m\n", path);
+        return -1;
+    }
+
+    /* Create the home directory */
     if (mkdir_p(path) != 0) {
         errmsg("Failed to create %s: %m\n", path);
         return -1;
@@ -377,6 +390,8 @@ make_homedir(const char *path, unsigned int uid, unsigned int gid)
         errmsg("Failed to chown %s: %m\n", path);
         return -1;
     }
+
+    verbose("Created homedir %s\n", path);
     return 0;
 }
 

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -323,7 +323,7 @@ change_user(const char *home)
 }
 
 static int
-mkdir_p(const char *path)
+mkdir_p(const char *path, mode_t mode)
 {
     /* Adapted from http://stackoverflow.com/a/2336245/119527 */
     const size_t len = strlen(path);
@@ -345,7 +345,7 @@ mkdir_p(const char *path)
             /* Temporarily truncate */
             *p = '\0';
 
-            if (mkdir(_path, S_IRWXU) != 0) {
+            if (mkdir(_path, mode) != 0) {
                 if (errno != EEXIST)
                     return -1;
             }
@@ -354,7 +354,7 @@ mkdir_p(const char *path)
         }
     }
 
-    if (mkdir(_path, S_IRWXU) != 0) {
+    if (mkdir(_path, mode) != 0) {
         if (errno != EEXIST)
             return -1;
     }
@@ -378,7 +378,7 @@ make_homedir(const char *path, unsigned int uid, unsigned int gid)
     }
 
     /* Create the home directory */
-    if (mkdir_p(path) != 0) {
+    if (mkdir_p(path, 0755) != 0) {
         errmsg("Failed to create %s: %m\n", path);
         return -1;
     }

--- a/scubainit/scubainit.c
+++ b/scubainit/scubainit.c
@@ -27,7 +27,7 @@
 #define ETC_SHADOW          "/etc/shadow"
 #define INVALID_PASSWORD    "x"
 
-#define USER_HOME          "/home/"
+#define USER_HOME           "/home"
 
 #define SCUBAINIT_UID       "SCUBAINIT_UID"
 #define SCUBAINIT_GID       "SCUBAINIT_GID"
@@ -49,6 +49,18 @@ static const char *m_full_name;
 
 static const char *m_user_hook;
 static const char *m_root_hook;
+
+
+static char *
+path_join(const char *p1, const char *p2)
+{
+    char *result;
+    if (asprintf(&result, "%s/%s", p1, p2) < 0) {
+        errmsg("Failed to allocate path string: %m\n");
+        exit(99);
+    }
+    return result;
+}
 
 
 /* Returns true if root should be used */
@@ -589,15 +601,8 @@ main(int argc, char **argv)
         exit(99);
 
     if (!use_root()) {
-        size_t home_len = sizeof(USER_HOME) + strlen(m_user) + 1;
-        home = malloc(home_len);
-        if (!home)
-            exit(99);
-
-        sprintf(home, "%s%s", USER_HOME, m_user);
-        home[home_len-1] = '\0';
-
-        /* Create scuba user home directory */
+        /* Create user home directory */
+        home = path_join(USER_HOME, m_user);
         if (make_homedir(home, m_uid, m_gid) != 0)
             goto fail;
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,8 @@ import sys
 from tempfile import TemporaryFile, NamedTemporaryFile
 import subprocess
 import shlex
+from pwd import getpwuid
+from grp import getgrgid
 
 import scuba.__main__ as main
 import scuba.constants
@@ -302,9 +304,9 @@ class TestMain(TmpDirTestCase):
         uid, username, gid, groupname = self._test_user()
 
         assert_equal(uid, os.getuid())
-        assert_equal(username, scuba.constants.SCUBA_USER)
+        assert_equal(username, getpwuid(os.getuid()).pw_name)
         assert_equal(gid, os.getgid())
-        assert_equal(groupname, scuba.constants.SCUBA_GROUP)
+        assert_equal(groupname, getgrgid(os.getgid()).gr_name)
 
 
     def test_user_root(self):


### PR DESCRIPTION
#70 stopped using `/scubaroot` and instead uses the same path in the container as outside.

This does the same with the current username (and groupname): Instead of using `scubauser`, Scuba will use the username and groupname of the user invoking scuba.

This builds on top of and supersedes #138.