### PR TITLE
Update build-test workflow to run on PR

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,11 @@
 name: Build and Test
 
-on: [push]
+# Run this workflow whenever someone pushes to any branch,
+# or when a PR is created or pushed to.
+on:
+  push:
+  pull_request:
+    types: [synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
This change should cause this workflow to be also run when someone creates or updates (pushes) a pull request.

https://github.community/t5/GitHub-Actions/Run-workflow-after-pushing-changes-to-a-PR/td-p/37016