### PR TITLE
scubainit: Properly handle system() return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - scubainit ignores matching passwd/group/shadow file entries when creating the
   user. This allows transparently running scuba as root. (#164)
+- Fixed bug where scubainit incorrectly displayed the exit status of a failed
+  hook script. (#165)
 
 
 ## [2.6.0] - 2020-03-25

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,7 @@ import scuba.dockerutil
 import scuba
 
 DOCKER_IMAGE = 'debian:8.2'
+SCUBAINIT_EXIT_FAIL = 99
 
 class TestMain(TmpDirTestCase):
 
@@ -661,6 +662,16 @@ class TestMain(TmpDirTestCase):
     def test_root_hook_runs_as_root(self):
         '''Verify root hook executes as root'''
         self._test_hook_runs_as('root', 0, 0)
+
+    def test_hook_failure_shows_correct_status(self):
+        testval = 42
+        out, err = self._test_one_hook(
+                'root',
+                'exit {}'.format(testval),
+                'dont care',
+                exp_retval = SCUBAINIT_EXIT_FAIL,
+                )
+        self.assertRegex(err, '^scubainit:.*exited with status {}'.format(testval))
 
 
     ############################################################################


### PR DESCRIPTION
Consider this `.scuba.yml`:
```yaml
image: alpine:3.10

hooks:
 root:
   script:
     - exit 42
```

Currently, when you run `scuba` it will output this:
```
scubainit: /.scuba/hooks/root.sh exited with status 10752
```

The reason is that `scubainit` is not properly decoding the return value of `system()`.

This MR updates `scubainit` to call `WEXITSTATUS()` to get the proper return code.

After:
```
scubainit: /.scuba/hooks/root.sh exited with status 42
```