### PR TITLE
Run build/test workflow only on pull_request

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 # Run this workflow whenever a PR is created or pushed to.
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,9 +1,7 @@
 name: Build and Test
 
-# Run this workflow whenever someone pushes to any branch,
-# or when a PR is created or pushed to.
+# Run this workflow whenever a PR is created or pushed to.
 on:
-  push:
   pull_request:
     types: [synchronize]
 


### PR DESCRIPTION
Ideally we would run only on `push`, but that doesn't cover when someone creates/updates a PR on a fork, so we added the `pull_request` trigger in cf00c12f. That works well for forks.

However, that means when *I* push to a branch on my project with an associated PR, the tests all run twice.

Pushing to a branch without a PR, and expecting a build to run, seems unlikely enough that we can use `pull_request` exclusively for now.

Also, I discovered (in failed attempt #166) that the previous solution: `syncrhonize` doesn't cover when a PR is *first* opened. So we add the `opened` trigger.

(repeat of #166 for testing)