### PR TITLE
Fix error where argcomplete is not installed

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     class argcomplete(object):
         @staticmethod
-        def autocomplete(_):
+        def autocomplete(*_, **__):
             pass
 import tempfile
 import shutil


### PR DESCRIPTION
The autocomplete() stub needs to accept kwargs.

Fixes #170