### PR TITLE
Allow docker arguments in scubafile

### DIFF
--- a/doc/yaml-reference.md
+++ b/doc/yaml-reference.md
@@ -109,9 +109,12 @@ aliases:
       - echo $FOO $BAR
 ```
 
-Aliases can override the top-level `docker_args`:
+Aliases can extend the top-level `docker_args`. The following example will
+produce the docker arguments `--privileged -v /tmp/bar:/tmp/bar` when executing
+the `example` alias:
+
 ```yaml
-docker_args: -v /tmp/foo:/tmp/foo
+docker_args: --privileged
 aliases:
   example:
     docker_args: -v /tmp/bar:/tmp/bar
@@ -119,6 +122,34 @@ aliases:
       - ls -l /tmp/
 ```
 
+Aliases can also opt to override the top-level `docker_args`, replacing it with
+a new value. This is achieved with the `!override` tag:
+
+```yaml
+docker_args: -v /tmp/foo:/tmp/foo
+aliases:
+  example:
+    docker_args: !override -v /tmp/bar:/tmp/bar
+    script:
+      - ls -l /tmp/
+```
+
+The content of the `docker_args` key is re-parsed as YAML in order to allow
+combining the `!override` tag with other tags; however, this requires quoting
+the value, since YAML forbids a plain-style scalar from beginning with a `!`
+(see [the spec](https://yaml.org/spec/1.2/spec.html#id2788859)). In the next
+example, the top-level alias is replaced with an explicit `!!null` tag, so
+that no additional arguments are passed to docker when executing the `example`
+alias:
+
+```yaml
+docker_args: -v /tmp/foo:/tmp/foo
+aliases:
+  example:
+    docker_args: !override '!!null'
+    script:
+      - ls -l /tmp/
+```
 
 ### `hooks`
 

--- a/doc/yaml-reference.md
+++ b/doc/yaml-reference.md
@@ -40,6 +40,15 @@ environment:
   - SECRET
 ```
 
+### `docker_args`
+
+The optional `docker_args` node allows additional docker arguments to be
+specified.
+
+Example:
+```yaml
+docker_args: --privileged
+```
 
 ### `aliases`
 
@@ -88,6 +97,16 @@ aliases:
       BAR: "New"
     script:
       - echo $FOO $BAR
+```
+
+Aliases can override the top-level `docker_args`:
+```yaml
+docker_args: -v /tmp/foo:/tmp/foo
+aliases:
+  example:
+    docker_args: -v /tmp/bar:/tmp/bar
+    script:
+      - ls -l /tmp/
 ```
 
 

--- a/doc/yaml-reference.md
+++ b/doc/yaml-reference.md
@@ -47,7 +47,17 @@ specified.
 
 Example:
 ```yaml
-docker_args: --privileged
+docker_args: --privileged -v "/tmp/hello world:/tmp/hello world"
+```
+
+The value of `docker_args` is parsed as shell command line arguments using
+[`shlex.split`](https://docs.python.org/3/library/shlex.html#shlex.split).
+
+The previous example could be equivalently written in YAML's [single-quoted
+style](https://yaml.org/spec/1.2/spec.html#id2788097):
+
+```yaml
+docker_args: '--privileged -v "/tmp/hello world:/tmp/hello world"'
 ```
 
 ### `aliases`

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -131,7 +131,8 @@ class ScubaDive:
         # These will be added to docker run cmdline
         self.env_vars = env
         self.volumes = []
-        self.options = docker_args or []
+        self.options = []
+        self.docker_args = docker_args or []
         self.workdir = None
 
         self.__locate_scubainit()
@@ -414,6 +415,12 @@ class ScubaDive:
             args += ['-w', self.workdir]
 
         args += self.options
+
+        # Precedence: (1) command-line -d, (2) alias docker_args, (3) top-level docker_args
+        if self.docker_args:
+            args += self.docker_args
+        elif self.context.docker_args is not None:
+            args += self.context.docker_args
 
         # Docker image
         args.append(self.context.image)

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -150,17 +150,15 @@ def _process_environment(node, name):
 
     return result
 
-def _get_entrypoint(data):
+def _get_nullable_str(data, key):
     # N.B. We can't use data.get() here, because that might return
-    # None, leading to ambiguity between entrypoint being absent or set
+    # None, leading to ambiguity between the key being absent or set
     # to a null value.
     #
     # "Note that a null is different from an empty string and that a
     # mapping entry with some key and a null value is valid and
     # different from not having that key in the mapping."
     #   - http://yaml.org/type/null.html
-    key = 'entrypoint'
-
     if not key in data:
         return None
 
@@ -175,9 +173,17 @@ def _get_entrypoint(data):
                 key, type(ep).__name__))
     return ep
 
+def _get_entrypoint(data):
+    return _get_nullable_str(data, 'entrypoint')
+
+def _get_docker_args(data):
+    args = _get_nullable_str(data, 'docker_args')
+    if args is not None:
+        args = shlex.split(args)
+    return args
 
 class ScubaAlias:
-    def __init__(self, name, script, image, entrypoint, environment, shell, as_root):
+    def __init__(self, name, script, image, entrypoint, environment, shell, as_root, docker_args):
         self.name = name
         self.script = script
         self.image = image
@@ -185,6 +191,7 @@ class ScubaAlias:
         self.environment = environment
         self.shell = shell
         self.as_root = as_root
+        self.docker_args = docker_args
 
     @classmethod
     def from_dict(cls, name, node):
@@ -194,9 +201,11 @@ class ScubaAlias:
         environment = None
         shell = None
         as_root = False
+        docker_args = None
 
         if isinstance(node, dict):  # Rich alias
             image = node.get('image')
+            docker_args = _get_docker_args(node)
             entrypoint = _get_entrypoint(node)
             environment = _process_environment(
                     node.get('environment'),
@@ -204,14 +213,14 @@ class ScubaAlias:
             shell = node.get('shell')
             as_root = node.get('root', as_root)
 
-        return cls(name, script, image, entrypoint, environment, shell, as_root)
+        return cls(name, script, image, entrypoint, environment, shell, as_root, docker_args)
 
 class ScubaContext:
     pass
 
 class ScubaConfig:
     def __init__(self, **data):
-        optional_nodes = ('image','aliases','hooks','entrypoint','environment','shell')
+        optional_nodes = ('image','aliases','hooks','entrypoint','environment','shell','docker_args')
 
         # Check for unrecognized nodes
         extra = [n for n in data if not n in optional_nodes]
@@ -222,6 +231,7 @@ class ScubaConfig:
         self._image = data.get('image')
         self._shell = data.get('shell', DEFAULT_SHELL)
         self._entrypoint = _get_entrypoint(data)
+        self._docker_args = _get_docker_args(data)
         self._load_aliases(data)
         self._load_hooks(data)
         self._environment = self._load_environment(data)
@@ -277,6 +287,10 @@ class ScubaConfig:
     def shell(self):
         return self._shell
 
+    @property
+    def docker_args(self):
+        return self._docker_args
+
 
     def process_command(self, command, image=None, shell=None):
         '''Processes a user command using aliases
@@ -297,6 +311,7 @@ class ScubaConfig:
         result.environment = self.environment.copy()
         result.shell = self.shell
         result.as_root = False
+        result.docker_args = self.docker_args
 
         if command:
             alias = self.aliases.get(command[0])
@@ -314,6 +329,8 @@ class ScubaConfig:
                     result.shell = alias.shell
                 if alias.as_root:
                     result.as_root = True
+                if alias.docker_args is not None:
+                    result.docker_args = alias.docker_args
 
                 # Merge/override the environment
                 if alias.environment:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -414,6 +414,29 @@ class TestMain:
 
         assert_str_equalish(out, data)
 
+    def test_arbitrary_docker_args_override_config(self):
+        '''Verify -d overrides any docker arguments in the config'''
+
+        with open('.scuba.yml', 'w') as f:
+            f.write('image: {}\n'.format(DOCKER_IMAGE))
+
+            # If this arg takes effect, the output of ls /lorem/ is no longer just "ipsum"
+            f.write('docker_args: {}\n'.format('-v="/lorem/default:/lorem/default"'))
+
+        data = 'Lorem ipsum dolor sit amet'
+        data_path = '/lorem/ipsum'
+
+        with NamedTemporaryFile(mode='wt') as tempf:
+            tempf.write(data)
+            tempf.flush()
+
+            args = [
+                '-d=-v {}:{}:ro,z'.format(tempf.name, data_path),
+                'ls', '/lorem',
+            ]
+            out, _ = self.run_scuba(args)
+
+        assert_str_equalish(out, 'ipsum')
 
     def test_nested_sript(self):
         '''Verify nested scripts works'''


### PR DESCRIPTION
Docker arguments can now be specified in the scubafile at the top-level or per-alias. The order of precendence for a single run is:

1. Arguments provided on command line via `-d`
2. Per-alias `docker_args` key
2. Top-level `docker_args` key

Explicitly providing a null or empty string value for `docker_args` at the alias level overrides the top-level `docker_args`, and results in no extra args passed to docker.

Resolves #144 