### PR TITLE
Append CLI --docker-arg to .scuba.yml docker_args

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -426,13 +426,13 @@ class ScubaDive:
 
         args += self.options
 
-        # Command-line -d
-        if self.docker_args:
-            args += self.docker_args
-
         # .scuba.yml (top-level or alias)
         if self.context.docker_args is not None:
             args += self.context.docker_args
+
+        # Command-line -d
+        if self.docker_args:
+            args += self.docker_args
 
         # Docker image
         args.append(self.context.image)

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -426,10 +426,12 @@ class ScubaDive:
 
         args += self.options
 
-        # Precedence: (1) command-line -d, (2) alias docker_args, (3) top-level docker_args
+        # Command-line -d
         if self.docker_args:
             args += self.docker_args
-        elif self.context.docker_args is not None:
+
+        # .scuba.yml (top-level or alias)
+        if self.context.docker_args is not None:
             args += self.context.docker_args
 
         # Docker image


### PR DESCRIPTION
This changes the behavior originally implemented in #177. Rather than overriding `docker_args` from `.scuba.yml`, now `-d` CLI args will be merged with them.

Closes #179.

cc @adamjseitz @xanarin