### PR TITLE
Add volumes to scubafile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add ability to specify volumes in `.scuba.yml` (#186)
+
+
 ## [2.8.0] - 2021-08-18
 ### Added
 - Add ability to specify additional docker arguments in `.scuba.yml` (#177)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -93,6 +93,30 @@ style <https://yaml.org/spec/1.2/spec.html#id2788097>`_:
 
     docker_args: '--privileged -v "/tmp/hello world:/tmp/hello world"'
 
+``volumes``
+-----------
+The optional ``volumes`` node allows additional `volumes
+<https://docs.docker.com/storage/volumes/>`_ or bind-mounts to be specified.
+``volumes`` is a mapping (dictionary) where each key is the container-path.
+In the simple form, the value is a string, the host-path to be bind-mounted:
+
+.. code-block:: yaml
+
+    volumes:
+      /var/lib/foo: /host/foo
+
+In the complex form, the value is a mapping which must contain a ``hostpath``
+subkey. It can also contain an ``options`` subkey with a comma-separated list
+of volume options:
+
+.. code-block:: yaml
+
+    volumes:
+      /var/lib/foo:
+        hostpath: /host/foo
+        options: ro,cached
+
+
 
 .. _conf_aliases:
 
@@ -190,6 +214,23 @@ alias:
         docker_args: !override '!!null'
         script:
           - ls -l /tmp/
+
+
+Aliases can extend or override the top-level ``volumes``:
+
+.. code-block:: yaml
+
+    volumes:
+      /var/lib/foo: /host/foo
+    aliases:
+      example:
+        volumes:
+          /var/lib/foo: /example/foo
+          /var/lib/bar: /example/bar
+        script:
+          - ls -l /var/lib/foo /var/lib/bar
+
+
 
 ``hooks``
 ---------

--- a/tests/test_scuba.py
+++ b/tests/test_scuba.py
@@ -298,3 +298,63 @@ class TestScubaContext:
             )
         result = ScubaContext.process_command(cfg, ['apple'])
         assert result.docker_args == ['--privileged']
+
+
+    ############################################################################
+    # volumes
+
+    def test_process_command_alias_extends_volumes(self):
+        '''aliases can extend the volumes'''
+        cfg = ScubaConfig(
+                image = 'default',
+                volumes = {
+                    '/foo': '/host/foo',
+                },
+                aliases = dict(
+                    apple = dict(
+                        script = [
+                            'banana cherry "pie is good"',
+                        ],
+                        volumes = {
+                            '/bar': '/host/bar',
+                        },
+                    ),
+                ),
+            )
+        result = ScubaContext.process_command(cfg, ['apple'])
+        vols = result.volumes
+        assert len(vols) == 2
+
+        v = vols['/foo']
+        assert v.container_path == '/foo'
+        assert v.host_path == '/host/foo'
+
+        v = vols['/bar']
+        assert v.container_path == '/bar'
+        assert v.host_path == '/host/bar'
+
+    def test_process_command_alias_updates_volumes(self):
+        '''aliases can extend the volumes'''
+        cfg = ScubaConfig(
+                image = 'default',
+                volumes = {
+                    '/foo': '/host/foo',
+                },
+                aliases = dict(
+                    apple = dict(
+                        script = [
+                            'banana cherry "pie is good"',
+                        ],
+                        volumes = {
+                            '/foo': '/alternate/foo',
+                        },
+                    ),
+                ),
+            )
+        result = ScubaContext.process_command(cfg, ['apple'])
+        vols = result.volumes
+        assert len(vols) == 1
+
+        v = vols['/foo']
+        assert v.container_path == '/foo'
+        assert v.host_path == '/alternate/foo'


### PR DESCRIPTION
This PR adds support for a new `volumes` key in `.scuba.yml` to bind-mount host directories into the container.

[**Latest docs build for `volumes` configuration**](https://scuba--186.org.readthedocs.build/en/186/configuration.html#volumes)


It supports both a simple form:
```yaml
volumes:
  /var/lib/foo: /host/foo
```

...and a complex form:
```yaml
volumes:
  /var/lib/foo:
    hostpath: /host/foo
    options: ro,cached
```

`volumes` can also be extended or overridden in an `alias`, as has now become the norm:
```yaml
volumes:
  /var/lib/foo: /host/foo
aliases:
  example:
    volumes:
      /var/lib/foo: /example/foo
      /var/lib/bar: /example/bar
    script:
      - ls -l /var/lib/foo /var/lib/bar
```

This closes #140.