### PR TITLE
Create host paths for volumes before starting Docker

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -130,6 +130,9 @@ def run_scuba(scuba_args):
             appmsg("Temp files not cleaned up")
             return 0
 
+        # Create volume host paths as current user
+        dive.try_create_volumes()
+
         # Explicitly pass sys.stdin/stdout/stderr so they apply to the
         # child process if overridden (by tests).
         return dockerutil.call(


### PR DESCRIPTION
Docker creates host paths as root, which creates permission problems when volumes are within user-owned directories (like `$HOME`). If a host path doesn't exist, scuba duplicates Docker's behavior and attempts to create an empty directory at that location, but owned by the user that ran scuba.

Closes #195