### PR TITLE
Move Python support to 3.7 - 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: False
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
     - run: git fetch --prune --unshallow
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Unit Test Results (Python ${{ matrix.python-version }})
         path: unit-test-results.xml
@@ -59,11 +59,11 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: artifacts/**/*.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Removed
+- Drop support for Python 3.5 - 3.6
+
 ## [2.10.1] - 2023-03-07
 ### Fixed
 - Create directories for volumes as invoking user rather than root. (#201)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def get_version():
 setup(
     name = 'scuba',
     version = get_version(),
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     description = 'Simplify use of Docker containers for building software',
     long_description = read_project_file('README.md'),
     long_description_content_type = 'text/markdown',


### PR DESCRIPTION
This drops support for Python 3.5 - 3.6.
This adds support (tests) for Python 3.10 - 3.11.

Fixes #202