### PR TITLE
Use Python 3.7 language features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ PyYAML
 pytest
 pytest-cov
 coverage
-mock; python_version < '3.3'

--- a/run_full_tests.py
+++ b/run_full_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 import subprocess
@@ -27,7 +27,7 @@ class InTempDir:
 def test1():
     with InTempDir(prefix='scuba-systest'):
         with open('.scuba.yml', 'w+t') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         in_data = 'success'
 

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -24,8 +24,8 @@ from .utils import format_cmdline, parse_env_var
 from .version import __version__
 
 
-def appmsg(fmt, *args):
-    print('scuba: ' + fmt.format(*args), file=sys.stderr)
+def appmsg(msg):
+    print('scuba: ' + msg, file=sys.stderr)
 
 
 def parse_scuba_args(argv):
@@ -76,7 +76,7 @@ def parse_scuba_args(argv):
     env = dict()
     for k,v in args.env_vars:
         if k in env:
-            ap.error("Duplicate env var {}".format(k))
+            ap.error(f"Duplicate env var {k!r}")
         env[k] = v
     args.env_vars = env
 
@@ -120,11 +120,8 @@ def run_scuba(scuba_args):
         run_args = dive.get_docker_cmdline()
 
         if g_verbose or scuba_args.dry_run:
-            print(str(dive))
-            print()
-
-            appmsg('Docker command line:')
-            print('$ ' + format_cmdline(run_args))
+            appmsg(str(dive) + "\n")
+            appmsg("Docker command line:\n$ " + format_cmdline(run_args))
 
         if scuba_args.dry_run:
             appmsg("Temp files not cleaned up")
@@ -150,10 +147,10 @@ def main(argv=None):
         rc = run_scuba(scuba_args) or 0
         sys.exit(rc)
     except ConfigError as e:
-        appmsg("Config error: " + str(e))
+        appmsg(f"Config error: {e}")
         sys.exit(128)
     except DockerExecuteError as e:
-        appmsg(str(e))
+        appmsg(f"{e}")
         sys.exit(2)
     except (ScubaError, DockerError) as e:
         appmsg(str(e))

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -31,14 +31,9 @@ call = __wrap_docker_exec(subprocess.call)
 def _run_docker(*args, capture=False):
     '''Run docker and raise DockerExecuteError on ENOENT'''
     args = ['docker'] + list(args)
-    kw = dict(
-            universal_newlines=True,    # TODO: Use 'text' in Python 3.7+
-            )
+    kw = dict(text=True)
     if capture:
-        kw.update(
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                )
+        kw.update(capture_output=True)
 
     return __wrap_docker_exec(subprocess.run)(args, **kw)
 

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -13,7 +13,7 @@ class NoSuchImageError(DockerError):
         self.image = image
 
     def __str__(self):
-        return 'No such image: {}'.format(self.image)
+        return f'No such image: {self.image}'
 
 
 def __wrap_docker_exec(func):
@@ -53,7 +53,7 @@ def docker_inspect(image):
     if not cp.returncode == 0:
         if 'no such image' in cp.stderr.lower():
             raise NoSuchImageError(image)
-        raise DockerError('Failed to inspect image: {}'.format(cp.stderr.strip()))
+        raise DockerError(f'Failed to inspect image: {cp.stderr.strip()}')
 
     return json.loads(cp.stdout)[0]
 
@@ -62,7 +62,7 @@ def docker_pull(image):
     # If this fails, the default docker stdout/stderr looks good to the user.
     cp = _run_docker('pull', image)
     if cp.returncode != 0:
-        raise DockerError('Failed to pull image "{}"'.format(image))
+        raise DockerError(f'Failed to pull image: {image}')
 
 def docker_inspect_or_pull(image):
     '''Inspects a docker image, pulling it if it doesn't exist'''
@@ -91,7 +91,7 @@ def get_images():
     )
 
     if not cp.returncode == 0:
-        raise DockerError('Failed to retrieve images: {}'.format(cp.stderr.strip()))
+        raise DockerError(f'Failed to retrieve images: {cp.stderr.strip()}')
 
     return cp.stdout.splitlines()
 
@@ -102,7 +102,7 @@ def get_image_command(image):
     try:
         return info['Config']['Cmd']
     except KeyError as ke:
-        raise DockerError('Failed to inspect image: JSON result missing key {}'.format(ke))
+        raise DockerError(f'Failed to inspect image: JSON result missing key {ke}')
 
 def get_image_entrypoint(image):
     '''Gets the image entrypoint'''
@@ -110,12 +110,12 @@ def get_image_entrypoint(image):
     try:
         return info['Config']['Entrypoint']
     except KeyError as ke:
-        raise DockerError('Failed to inspect image: JSON result missing key {}'.format(ke))
+        raise DockerError(f'Failed to inspect image: JSON result missing key {ke}')
 
 
 def make_vol_opt(hostdir, contdir, options=None):
     '''Generate a docker volume option'''
-    vol = '--volume={}:{}'.format(hostdir, contdir)
+    vol = f'--volume={hostdir}:{contdir}'
     if options != None:
         if isinstance(options, str):
             options = (options,)

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -104,12 +104,12 @@ class ScubaDive:
         level = 0
 
         def writelist(name, vals):
-            writeln(s, '{}{}:'.format(indent*level, name))
+            writeln(s, f'{indent * level}{name}:')
             for val in vals or ():
-                writeln(s, '{}{}'.format(indent*(level+1), val))
+                writeln(s, f'{indent * (level + 1)}{val}')
 
         def writescl(name, val=''):
-            writeln(s, '{}{:<14s}{}'.format(indent*level, name+':', val))
+            writeln(s, f"{indent * level}{name + ':':<14s}{val}")
 
         writeln(s, 'ScubaDive')
         level += 1
@@ -120,8 +120,8 @@ class ScubaDive:
 
         writelist('options', self.options)
         writelist('docker_args', self.docker_args)
-        writelist('env_vars', ('{}={}'.format(*e) for e in self.env_vars.items()))
-        writelist('volumes', ('{} => {} {}'.format(hp, cp, opt)
+        writelist('env_vars', (f'{name}={val}' for name, val in self.env_vars.items()))
+        writelist('volumes', (f'{hp} => {cp} {opt}'
                               for hp, cp, opt in self.__get_vol_opts()))
 
         writescl('context')
@@ -176,7 +176,7 @@ class ScubaDive:
                 # Docker will create this path later as root
                 pass
             except OSError as err:
-                raise ScubaError('Error creating volume host path: {}'.format(err)) from err
+                raise ScubaError(f'Error creating volume host path: {err}') from err
 
     def add_option(self, option):
         '''Add another option to the docker run invocation
@@ -193,7 +193,7 @@ class ScubaDive:
 
         scubainit_path = os.path.join(pkg_path, 'scubainit')
         if not os.path.isfile(scubainit_path):
-            raise ScubaError('scubainit not found at "{}"'.format(scubainit_path))
+            raise ScubaError(f'scubainit not found at {scubainit_path!r}')
         return scubainit_path
 
     def __make_scubadir(self):
@@ -210,7 +210,7 @@ class ScubaDive:
         self.vol_opts = ['z']
 
         # Pass variables to scubainit
-        self.add_env('SCUBAINIT_UMASK', '{:04o}'.format(get_umask()))
+        self.add_env('SCUBAINIT_UMASK', f'{get_umask():04o}')
 
         # Check if the CLI args specify "run as root", or if the command (alias) does
         if not self.as_root and not self.context.as_root:
@@ -254,7 +254,7 @@ class ScubaDive:
 
         # Make scubainit the real entrypoint, and use the defined entrypoint as
         # the docker command (if it exists)
-        self.add_option('--entrypoint={}'.format(scubainit_cpath))
+        self.add_option(f'--entrypoint={scubainit_cpath}')
 
         self.docker_cmd = []
         if self.entrypoint_override is not None:
@@ -314,11 +314,11 @@ class ScubaDive:
             return
 
         # Generate the hook script, mount it into the container, and tell scubainit
-        with self.open_scubadir_file('hooks/{}.sh'.format(name), 'wt') as f:
+        with self.open_scubadir_file(f'hooks/{name}.sh', 'wt') as f:
 
-            self.add_env('SCUBAINIT_HOOK_{}'.format(name.upper()), f.container_path)
+            self.add_env(f'SCUBAINIT_HOOK_{name.upper()}', f.container_path)
 
-            writeln(f, '#!{}'.format(shell))
+            writeln(f, f'#!{shell}')
             writeln(f, '# Auto-generated from .scuba.yml')
             writeln(f, 'set -e')
             for cmd in script:
@@ -338,7 +338,7 @@ class ScubaDive:
         ]
 
         for name,val in self.env_vars.items():
-            args.append('--env={}={}'.format(name, val))
+            args.append(f'--env={name}={val}')
 
         for hostpath, contpath, options in self.__get_vol_opts():
             args.append(make_vol_opt(hostpath, contpath, options))

--- a/scuba/version.py
+++ b/scuba/version.py
@@ -47,13 +47,13 @@ def get_version():
         if commits == 0 and not rev.endswith('dirty'):
             return BASE_VERSION
 
-        return '{}+{}-{}'.format(BASE_VERSION, commits, rev)
+        return f'{BASE_VERSION}+{commits}-{rev}'
 
 
     # Git archive
     # If this was produced via `git archive`, we'll use the version it provides
     if not git_archive_rev.startswith('$'):
-        return '{}+g{}'.format(BASE_VERSION, git_archive_rev)
+        return f'{BASE_VERSION}+g{git_archive_rev}'
 
 
     # Package resource

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def get_version():
     # If CI_VERSION_BUILD_NUMBER is set, append that to the base version
     build_num = os.getenv('CI_VERSION_BUILD_NUMBER')
     if build_num:
-        return '{}.{}'.format(scuba.version.BASE_VERSION, build_num)
+        return f'{scuba.version.BASE_VERSION}.{build_num}'
 
     # Otherwise, use the auto-versioning
     return scuba.version.__version__

--- a/tests/const.py
+++ b/tests/const.py
@@ -19,4 +19,4 @@ if __name__ == '__main__':
     for name, val in dict(vars()).items():
         if name.startswith('_'):
             continue
-        print('{}="{}"'.format(name, val))
+        print(f'{name}="{val}"')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ class TestMain:
         '''Verify basic scuba functionality'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = ['/bin/echo', '-n', 'my output']
         out, _ = self.run_scuba(args)
@@ -99,7 +99,7 @@ class TestMain:
         '''Verify scuba works with no given command'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format('scuba/hello'))
+            f.write("image: scuba/hello\n")
 
         out, _ = self.run_scuba([])
         assert_str_equalish(out, 'Hello world')
@@ -108,7 +108,7 @@ class TestMain:
         '''Verify scuba gracefully handles an image with no Cmd and no user command'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format('scuba/scratch'))
+            f.write("image: scuba/scratch\n")
 
         # ScubaError -> exit(128)
         out, _ = self.run_scuba([], 128)
@@ -117,7 +117,7 @@ class TestMain:
         '''Verify scuba handles a get_image_command error'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         def mocked_gic(*args, **kw):
             raise scuba.dockerutil.DockerError('mock error')
@@ -141,15 +141,15 @@ class TestMain:
     def test_multiline_alias_no_args_error(self):
         '''Verify config errors from passing arguments to multi-line alias are caught'''
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   multi:
                     script:
                       - echo multi
                       - echo line
                       - echo alias
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         # ConfigError -> exit(128)
         self.run_scuba(['multi', 'with', 'args'], 128)
@@ -170,7 +170,7 @@ class TestMain:
         '''Verify scuba gracefully handles docker not being installed'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = ['/bin/echo', '-n', 'my output']
 
@@ -187,7 +187,7 @@ class TestMain:
         '''Verify scuba handles --dry-run and --verbose'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = ['--dry-run', '--verbose', '/bin/false']
 
@@ -202,7 +202,7 @@ class TestMain:
         '''Verify scuba handles cmdline args'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         with open('test.sh', 'w') as f:
             f.write('#!/bin/sh\n')
@@ -220,7 +220,7 @@ class TestMain:
         '''Verify files created under scuba have correct ownership'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         filename = 'newfile.txt'
 
@@ -233,7 +233,7 @@ class TestMain:
 
     def _setup_test_tty(self):
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         with open('check_tty.sh', 'w') as f:
             f.write('#!/bin/sh\n')
@@ -261,7 +261,7 @@ class TestMain:
     def test_redirect_stdin(self):
         '''Verify stdin redirection works'''
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         test_str = 'hello world'
         with TemporaryFile(prefix='scubatest-stdin', mode='w+t') as stdin:
@@ -277,7 +277,7 @@ class TestMain:
                    expected_gid, expected_groupname,
                    scuba_args=[]):
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = scuba_args + ['/bin/sh', '-c', 'echo $(id -u) $(id -un) $(id -g) $(id -gn)']
         out, _ = self.run_scuba(args)
@@ -328,14 +328,14 @@ class TestMain:
     def test_user_root_alias(self):
         '''Verify that aliases can set whether the container is run as root'''
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   root_test:
                     root: true
                     script:
                       - echo $(id -u) $(id -un) $(id -g) $(id -gn)
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         out, _ = self.run_scuba(["root_test"])
         uid, username, gid, groupname = out.split()
@@ -348,14 +348,14 @@ class TestMain:
         # No one should ever specify 'root: false' in an alias, but Scuba should behave
         # correctly if they do
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   no_root_test:
                     root: false
                     script:
                       - echo $(id -u) $(id -un) $(id -g) $(id -gn)
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         out, _ = self.run_scuba(["no_root_test"])
         uid, username, gid, groupname = out.split()
@@ -367,7 +367,7 @@ class TestMain:
 
     def _test_home_writable(self, scuba_args=[]):
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = scuba_args + ['/bin/sh', '-c', 'echo success >> ~/testfile; cat ~/testfile']
         out, _ = self.run_scuba(args)
@@ -384,8 +384,7 @@ class TestMain:
 
         expected = os.path.join('/home', username)
         if homedir != expected:
-            warnings.warn("Homedir ({}) is not as expected ({}); test inconclusive"
-                    .format(homedir, expected))
+            warnings.warn(f"Homedir ({homedir}) is not as expected ({expected}); test inconclusive")
 
         with InTempDir(prefix='tmp-scubatest-', dir=homedir):
             self._test_home_writable()
@@ -400,7 +399,7 @@ class TestMain:
         '''Verify -d successfully passes arbitrary docker arguments'''
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         data = 'Lorem ipsum dolor sit amet'
         data_path = '/lorem/ipsum'
@@ -410,7 +409,7 @@ class TestMain:
             tempf.flush()
 
             args = [
-                '-d=-v {}:{}:ro,z'.format(tempf.name, data_path),
+                f'-d=-v {tempf.name}:{data_path}:ro,z',
                 'cat', data_path,
             ]
             out, _ = self.run_scuba(args)
@@ -427,10 +426,10 @@ class TestMain:
         def mount_dummy(name):
             assert name not in expfiles
             expfiles.add(name)
-            return '-v "{}:{}"\n'.format(dummy.absolute(), os.path.join(tgtdir, name))
+            return f'-v "{dummy.absolute()}:{tgtdir}/{name}"\n'
 
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
             f.write('docker_args: ' + mount_dummy('one'))
 
         args = [
@@ -445,7 +444,7 @@ class TestMain:
     def test_nested_sript(self):
         '''Verify nested scripts works'''
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
             f.write('aliases:\n')
             f.write('  foo:\n')
             f.write('    script:\n')
@@ -507,7 +506,7 @@ class TestMain:
 
         with open('new.sh', 'w') as f:
             f.write('#!/bin/sh\n')
-            f.write('echo "{}"\n'.format(test_str))
+            f.write(f'echo "{test_str}\"\n')
         make_executable('new.sh')
 
         args = [
@@ -552,7 +551,7 @@ class TestMain:
 
         with open('new.sh', 'w') as f:
             f.write('#!/bin/sh\n')
-            f.write('echo "{}"\n'.format(test_str))
+            f.write(f'echo "{test_str}\"\n')
         make_executable('new.sh')
 
         args = [
@@ -643,7 +642,7 @@ class TestMain:
         with open('foo/bar.txt', 'w') as f:
             f.write(test_string)
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
             f.write('aliases:\n')
             f.write('  alias1:\n')
             f.write('    script:\n')
@@ -658,9 +657,9 @@ class TestMain:
 
     def _test_one_hook(self, hookname, hookcmd, cmd, exp_retval=0):
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
             f.write('hooks:\n')
-            f.write('  {}: {}\n'.format(hookname, hookcmd))
+            f.write(f'  {hookname}: {hookcmd}\n')
 
         args = ['/bin/sh', '-c', cmd]
         return self.run_scuba(args, exp_retval=exp_retval)
@@ -691,11 +690,11 @@ class TestMain:
         testval = 42
         out, err = self._test_one_hook(
                 'root',
-                'exit {}'.format(testval),
+                f'exit {testval}',
                 'dont care',
                 exp_retval = SCUBAINIT_EXIT_FAIL,
                 )
-        assert re.match('^scubainit: .* exited with status {}$'.format(testval), err)
+        assert re.match(f'^scubainit: .* exited with status {testval}$', err)
 
 
     ############################################################################
@@ -704,7 +703,7 @@ class TestMain:
     def test_env_var_keyval(self):
         '''Verify -e KEY=VAL works'''
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
         args = [
             '-e', 'KEY=VAL',
             '/bin/sh', '-c', 'echo $KEY',
@@ -715,7 +714,7 @@ class TestMain:
     def test_env_var_key_only(self, monkeypatch):
         '''Verify -e KEY works'''
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
         args = [
             '-e', 'KEY',
             '/bin/sh', '-c', 'echo $KEY',
@@ -728,8 +727,8 @@ class TestMain:
     def test_env_var_sources(self, monkeypatch):
         '''Verify scuba handles all possible environment variable sources'''
         with open('.scuba.yml', 'w') as f:
-            f.write(r'''
-                image: {image}
+            f.write(fr'''
+                image: {DOCKER_IMAGE}
                 environment:
                   FOO: Top-level
                   BAR: 42
@@ -748,7 +747,7 @@ class TestMain:
                       FOO: Overridden
                       MORE: Hello world
                       EXTERNAL_3:
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         args = [
             '-e', 'EXTERNAL_1',
@@ -778,7 +777,7 @@ class TestMain:
     def test_builtin_env__SCUBA_ROOT(self, in_tmp_path):
         '''Verify SCUBA_ROOT is set in container'''
         with open('.scuba.yml', 'w') as f:
-            f.write('image: {}\n'.format(DOCKER_IMAGE))
+            f.write(f'image: {DOCKER_IMAGE}\n')
 
         args = ['/bin/sh', '-c', 'echo $SCUBA_ROOT']
         out, _ = self.run_scuba(args)
@@ -792,13 +791,13 @@ class TestMain:
     def test_use_top_level_shell_override(self):
         '''Verify that the shell can be overriden at the top level'''
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 shell: /bin/bash
                 aliases:
                   check_shell:
                     script: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         out, _ = self.run_scuba(['check_shell'])
         # If we failed to override, the shebang would be #!/bin/sh
@@ -807,15 +806,15 @@ class TestMain:
     def test_alias_level_shell_override(self):
         '''Verify that the shell can be overriden at the alias level without affecting other aliases'''
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   shell_override:
                     shell: /bin/bash
                     script: readlink -f /proc/$$/exe
                   default_shell:
                     script: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
         out, _ = self.run_scuba(['shell_override'])
         assert_str_equalish("/bin/bash", out)
 
@@ -827,12 +826,12 @@ class TestMain:
     def test_cli_shell_override(self):
         '''Verify that the shell can be overriden by the CLI'''
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   default_shell:
                     script: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
 
         out, _ = self.run_scuba(['--shell', '/bin/bash', 'default_shell'])
         assert_str_equalish("/bin/bash", out)
@@ -844,37 +843,37 @@ class TestMain:
 
         # Test top-level << alias-level
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 shell: /bin/this_does_not_exist
                 aliases:
                   shell_override:
                     shell: /bin/bash
                     script: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
         out, _ = self.run_scuba(['shell_override'])
         assert_str_equalish("/bin/bash", out)
 
         # Test alias-level << CLI
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 aliases:
                   shell_overridden:
                     shell: /bin/this_is_not_a_real_shell
                     script: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
         out, _ = self.run_scuba(['--shell', '/bin/bash', 'shell_overridden'])
         assert_str_equalish("/bin/bash", out)
 
         # Test top-level << CLI
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 shell: /bin/this_is_not_a_real_shell
                 aliases:
                   shell_check: readlink -f /proc/$$/exe
-                '''.format(image=DOCKER_IMAGE))
+                ''')
         out, _ = self.run_scuba(['--shell', '/bin/bash', 'shell_check'])
         assert_str_equalish("/bin/bash", out)
 
@@ -894,19 +893,16 @@ class TestMain:
         (aliasdata / "thing").write_text("from the alias\n")
 
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 volumes:
-                  /topdata: {topdata_dir}
+                  /topdata: {topdata.absolute()}
                 aliases:
                   doit:
                     volumes:
-                      /aliasdata: {aliasdata_dir}
+                      /aliasdata: {aliasdata.absolute()}
                     script: "cat /topdata/thing /aliasdata/thing"
-                '''.format(image = DOCKER_IMAGE,
-                           topdata_dir = topdata.absolute(),
-                           aliasdata_dir = aliasdata.absolute(),
-                           ))
+                ''')
 
         out, _ = self.run_scuba(['doit'])
         out = out.splitlines()
@@ -926,19 +922,16 @@ class TestMain:
         (aliasdata / "thing").write_text("from the alias\n")
 
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 volumes:
-                  /data: {topdata_dir}
+                  /data: {topdata.absolute()}
                 aliases:
                   doit:
                     volumes:
-                      /data: {aliasdata_dir}
+                      /data: {aliasdata.absolute()}
                     script: "cat /data/thing"
-                '''.format(image = DOCKER_IMAGE,
-                           topdata_dir = topdata.absolute(),
-                           aliasdata_dir = aliasdata.absolute(),
-                           ))
+                ''')
 
         # Run a non-alias command
         out, _ = self.run_scuba(['cat', '/data/thing'])
@@ -957,13 +950,11 @@ class TestMain:
         testfile = userdir / 'test.txt'
 
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 volumes:
-                  /userdir: {user_dir}
-                '''.format(image = DOCKER_IMAGE,
-                           user_dir = userdir.absolute(),
-                           ))
+                  /userdir: {userdir.absolute()}
+                ''')
 
         self.run_scuba(['touch', '/userdir/test.txt'])
 
@@ -983,17 +974,15 @@ class TestMain:
         rootdir.mkdir()
 
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 volumes:
-                  /userdir: {user_dir}
+                  /userdir: {userdir.absolute()}
                 aliases:
                    doit:
                       root: true
                       script: "touch /userdir/test.txt"
-                '''.format(image = DOCKER_IMAGE,
-                           user_dir = userdir.absolute(),
-                           ))
+                ''')
 
         try:
             # Prevent current user from creating directory
@@ -1020,12 +1009,10 @@ class TestMain:
         rootdir.write_text("lied about the dir")
 
         with open('.scuba.yml', 'w') as f:
-            f.write('''
-                image: {image}
+            f.write(f'''
+                image: {DOCKER_IMAGE}
                 volumes:
-                  /userdir: {user_dir}
-                '''.format(image = DOCKER_IMAGE,
-                           user_dir = userdir.absolute(),
-                           ))
+                  /userdir: {userdir.absolute()}
+                ''')
 
         self.run_scuba(['touch', '/userdir/test.txt'], 128)


### PR DESCRIPTION
1. Where appropriate, convert to [f-strings](https://peps.python.org/pep-0498/). This was accomplished using `flynt` (https://github.com/ikamensh/flynt) with manual review and a few changes.
2. Take advantage of the new `subprocess.run()` arguments: `text` and `capture_output`.