### PR TITLE
Rename 'master' branch to 'main'

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,10 +1,10 @@
 name: Upload to Test PyPI
 
-# On every push to master, push to Test PyPI
+# On every push to main, push to Test PyPI
 on:
   push:
     branches:
-      - master
+      - main
 
 # TODO: De-duplicate with python-publish-release.yml
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-SCUBA  [![Build Status](https://github.com/JonathonReinhart/scuba/actions/workflows/build-test.yml/badge.svg)](https://github.com/JonathonReinhart/scuba/actions/workflows/build-test.yml) [![codecov.io](https://codecov.io/github/JonathonReinhart/scuba/coverage.svg?branch=master)](https://codecov.io/github/JonathonReinhart/scuba?branch=master) [![PyPI](https://img.shields.io/pypi/v/scuba.svg)](https://pypi.python.org/pypi/scuba) [![Docs](https://readthedocs.org/projects/scuba/badge/?version=latest)](https://scuba.readthedocs.io/)
+SCUBA  [![Build Status](https://github.com/JonathonReinhart/scuba/actions/workflows/build-test.yml/badge.svg)](https://github.com/JonathonReinhart/scuba/actions/workflows/build-test.yml) [![codecov.io](https://codecov.io/github/JonathonReinhart/scuba/coverage.svg?branch=main)](https://codecov.io/github/JonathonReinhart/scuba?branch=main) [![PyPI](https://img.shields.io/pypi/v/scuba.svg)](https://pypi.python.org/pypi/scuba) [![Docs](https://readthedocs.org/projects/scuba/badge/?version=latest)](https://scuba.readthedocs.io/)
 -----
 ![SCUBA](docs/images/SCUBA.png)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -27,11 +27,11 @@ versioning scheme. Consider a base version of `1.2.3`:
    base version.
 
 2. **Test PyPI** - Scuba is automatically deployed (via Travis-CI) to the
-   [PyPI Testing Site](testpypi.python.org) upon each push to the `master`
+   [PyPI Testing Site](testpypi.python.org) upon each push to the `main`
    branch. PyPI requires non-local [PEP 440](https://www.python.org/dev/peps/pep-0440)
    -compliant versions. Because of this, the Travis CI build number is appended
    to the base version, excluding any Git information, e.g. `1.2.3.456` where
-   `456` is the build number. This ensures that the latest build on `master`
+   `456` is the build number. This ensures that the latest build on `main`
    will always be deployed to PyPI testing as the newest version.
 
 3. **Git clone** - Scuba can be run from a local Git repository.


### PR DESCRIPTION
`master` has already been renamed `main` via the GitHub UI. Complete the remaining changes.