### PR TITLE
Format with Black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,17 @@
+# Enforce code formatting with Black
+# https://black.readthedocs.io/en/stable/integrations/github_actions.html
+name: Blacken
+
+on: [push, pull_request]
+
+jobs:
+  blacken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          # TODO(#203): Remove target-version when we add pyproject.toml
+          options: "--check --color --diff --target-version=py37"
+          src: "."
+          version: "~= 23.0"  # Must match requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing Guide
+*This file is incomplete. Feel free to open an issue if there is missing
+information you desire.*
+
+## Code Format
+Scuba is compliant with the [Black](https://black.readthedocs.io/)
+code style. Code format in PRs is verified by a GitHub action.
+
+To check code formatting:
+```
+$ ./code_format.py
+```
+
+To fix code formatting:
+```
+$ ./code_format.py --fix
+```

--- a/code_format.py
+++ b/code_format.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import argparse
+import black
+
+
+def _run_black(fix: bool) -> bool:
+    args = [
+        # TODO(#203): Remove target-version when we add pyproject.toml
+        "--target-version=py37",
+        ".",
+    ]
+
+    if not fix:
+        # check only
+        args = args + [
+            "--check",
+            "--color",
+            "--diff",
+        ]
+
+    status = black.main(args, standalone_mode=False)
+
+    if status == 0:
+        return True
+    if status == 1:
+        return False
+    raise Exception(f"Unexpected exit status: {status}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Modify files to fix formatting",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    print(f"{'Fixing' if args.fix else 'Checking'} code formatting...")
+    ok = _run_black(args.fix)
+    if not ok:
+        print("\nTo fix, rerun with --fix")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,8 @@
 # add these directories to sys.path here.
 import sys
 from pathlib import Path
-doc_dir = Path('.').absolute()
+
+doc_dir = Path(".").absolute()
 
 sys.path.append(str(doc_dir.parent))
 import scuba.version
@@ -18,14 +19,14 @@ import scuba.version
 
 # -- Project information -----------------------------------------------------
 
-project = 'Scuba'
-copyright = '2021, Jonathon Reinhart'
-author = 'Jonathon Reinhart'
+project = "Scuba"
+copyright = "2021, Jonathon Reinhart"
+author = "Jonathon Reinhart"
 
 # The short X.Y version
 version = scuba.version.__version__
 # The full version, including alpha/beta/rc tags
-#release = ''
+# release = ''
 
 
 # -- General configuration ---------------------------------------------------
@@ -34,16 +35,16 @@ version = scuba.version.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser',
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -51,11 +52,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
-html_logo = './images/SCUBA.png'
+html_logo = "./images/SCUBA.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,4 @@ Local builds made easy, using Docker.
    bash_completion
    environment
    changelog
+   contributing

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ PyYAML
 pytest
 pytest-cov
 coverage
+black~=23.0  # Must match .github/workflows/black.yml
 -r docs/requirements.txt

--- a/run_full_tests.py
+++ b/run_full_tests.py
@@ -9,7 +9,7 @@ from tests.const import DOCKER_IMAGE
 
 
 class InTempDir:
-    def __init__(self, suffix='', prefix='tmp', delete=True):
+    def __init__(self, suffix="", prefix="tmp", delete=True):
         self.delete = delete
         self.temp_path = tempfile.mkdtemp(suffix=suffix, prefix=prefix)
 
@@ -24,26 +24,29 @@ class InTempDir:
         if self.delete:
             shutil.rmtree(self.temp_path)
 
+
 def test1():
-    with InTempDir(prefix='scuba-systest'):
-        with open('.scuba.yml', 'w+t') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+    with InTempDir(prefix="scuba-systest"):
+        with open(".scuba.yml", "w+t") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        in_data = 'success'
+        in_data = "success"
 
-        with open('file.in', 'w+t') as f:
+        with open("file.in", "w+t") as f:
             f.write(in_data)
 
-        subprocess.check_call(['scuba', '/bin/sh', '-c', 'cat file.in >> file.out'])
+        subprocess.check_call(["scuba", "/bin/sh", "-c", "cat file.in >> file.out"])
 
-        with open('file.out', 'rt') as f:
+        with open("file.out", "rt") as f:
             out_data = f.read()
 
         assert in_data == out_data
 
+
 def main():
     test1()
-    print('All is good.')
+    print("All is good.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -8,33 +8,42 @@ from .constants import *
 from .utils import *
 from .dockerutil import make_vol_opt
 
+
 class ConfigError(Exception):
     pass
+
 
 class ConfigNotFoundError(ConfigError):
     pass
 
+
 class OverrideMixin:
-    '''
+    """
     A mixin class that indicates an instance's value should override something
 
     This class is mixed into objects loaded from YAML with an !override tag,
     and any object can be checked if it is an OverrideMixin using isinstance().
-    '''
+    """
+
     pass
 
+
 class OverrideNone(OverrideMixin):
-    '''
+    """
     Represents a None value that also has Override behavior
-    '''
+    """
+
     def __bool__(self):
         return False
+
 
 class OverrideList(collections.UserList, OverrideMixin):
     pass
 
+
 class OverrideStr(str, OverrideMixin):
     pass
+
 
 # http://stackoverflow.com/a/9577670
 class Loader(yaml.SafeLoader):
@@ -47,7 +56,7 @@ class Loader(yaml.SafeLoader):
         super().__init__(stream)
 
     def from_yaml(self, node):
-        '''
+        """
         Implementes a !from_yaml constructor with the following syntax:
             !from_yaml filename key
 
@@ -61,7 +70,7 @@ class Loader(yaml.SafeLoader):
             !from_yaml external.yml pop
             !from_yaml external.yml foo.bar.pop
             !from_yaml "another file.yml" "foo bar.snap crackle.pop"
-        '''
+        """
 
         # Load the content from the node, as a scalar
         content = self.construct_scalar(node)
@@ -69,7 +78,7 @@ class Loader(yaml.SafeLoader):
         # Split on unquoted spaces
         parts = shlex.split(content)
         if len(parts) != 2:
-            raise yaml.YAMLError('Two arguments expected to !from_yaml')
+            raise yaml.YAMLError("Two arguments expected to !from_yaml")
         filename, key = parts
 
         # path is relative to the current YAML document
@@ -78,7 +87,7 @@ class Loader(yaml.SafeLoader):
         # Load the other YAML document
         doc = self._cache.get(path)
         if not doc:
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 doc = yaml.load(f, self.__class__)
                 self._cache[path] = doc
 
@@ -86,16 +95,18 @@ class Loader(yaml.SafeLoader):
         try:
             cur = doc
             # Use a negative look-behind to split the key on non-escaped '.' characters
-            for k in re.split(r'(?<!\\)\.', key):
-                cur = cur[k.replace('\\.', '.')]  # Be sure to replace any escaped '.' characters with *just* the '.'
+            for k in re.split(r"(?<!\\)\.", key):
+                cur = cur[
+                    k.replace("\\.", ".")
+                ]  # Be sure to replace any escaped '.' characters with *just* the '.'
         except KeyError:
-            raise yaml.YAMLError(f'Key {key!r} not found in {filename}')
+            raise yaml.YAMLError(f"Key {key!r} not found in {filename}")
         return cur
 
     def override(self, node):
-        '''
+        """
         Implements !override constructor
-        '''
+        """
         # Load the content from the node, as a scalar
         content = self.construct_scalar(node)
 
@@ -105,7 +116,9 @@ class Loader(yaml.SafeLoader):
             obj = OverrideNone()
         else:
             objtype = type(obj)
-            mixin_type = type('Override' + objtype.__name__, (objtype, OverrideMixin), dict())
+            mixin_type = type(
+                "Override" + objtype.__name__, (objtype, OverrideMixin), dict()
+            )
 
             try:
                 obj.__class__ = mixin_type
@@ -115,56 +128,60 @@ class Loader(yaml.SafeLoader):
 
         return obj
 
-Loader.add_constructor('!from_yaml', Loader.from_yaml)
-Loader.add_constructor('!override', Loader.override)
+
+Loader.add_constructor("!from_yaml", Loader.from_yaml)
+Loader.add_constructor("!override", Loader.override)
 
 
 def find_config():
-    '''Search up the directory hierarchy for .scuba.yml
+    """Search up the directory hierarchy for .scuba.yml
 
     Returns: path, rel, config on success, or None if not found
         path    The absolute path of the directory where .scuba.yml was found
         rel     The relative path from the directory where .scuba.yml was found
                 to the current directory
         config  The loaded configuration
-    '''
-    cross_fs = 'SCUBA_DISCOVERY_ACROSS_FILESYSTEM' in os.environ
+    """
+    cross_fs = "SCUBA_DISCOVERY_ACROSS_FILESYSTEM" in os.environ
     path = os.getcwd()
 
-    rel = ''
+    rel = ""
     while True:
         cfg_path = os.path.join(path, SCUBA_YML)
         if os.path.exists(cfg_path):
             return path, rel, load_config(cfg_path)
 
         if not cross_fs and os.path.ismount(path):
-            msg = f'{SCUBA_YML} not found here or any parent up to mount point {path}' \
-                   + '\nStopping at filesystem boundary (SCUBA_DISCOVERY_ACROSS_FILESYSTEM not set).'
-            raise ConfigNotFoundError(msg)
+            raise ConfigNotFoundError(
+                f"{SCUBA_YML} not found here or any parent up to mount point {path}"
+                "\nStopping at filesystem boundary"
+                " (SCUBA_DISCOVERY_ACROSS_FILESYSTEM not set)."
+            )
 
         # Traverse up directory hierarchy
         path, rest = os.path.split(path)
         if not rest:
-            raise ConfigNotFoundError(f'{SCUBA_YML} not found here or any parent directories')
+            raise ConfigNotFoundError(
+                f"{SCUBA_YML} not found here or any parent directories"
+            )
 
         # Accumulate the relative path back to where we started
         rel = os.path.join(rest, rel)
 
 
 def _process_script_node(node, name):
-    '''Process a script-type node
+    """Process a script-type node
 
     This handles nodes that follow the *Common script schema*,
     as outlined in doc/yaml-reference.md.
-    '''
+    """
     if isinstance(node, str):
         # The script is just the text itself
         return [node]
 
-
     if isinstance(node, dict):
         # There must be a "script" key, which must be a list of strings
-        script = node.get('script')
+        script = node.get("script")
         if not script:
             raise ConfigError(f"{name}: must have a 'script' subkey")
 
@@ -189,16 +206,19 @@ def _process_environment(node, name):
     elif isinstance(node, dict):
         for k, v in node.items():
             if v is None:
-                v = os.getenv(k, '')
+                v = os.getenv(k, "")
             result[k] = str(v)
     elif isinstance(node, list):
         for e in node:
             k, v = parse_env_var(e)
             result[k] = v
     else:
-        raise ConfigError(f"'{name}' must be list or mapping, not {type(node).__name__}")
+        raise ConfigError(
+            f"'{name}' must be list or mapping, not {type(node).__name__}"
+        )
 
     return result
+
 
 def _get_nullable_str(data, key):
     # N.B. We can't use data.get() here, because that might return
@@ -216,19 +236,21 @@ def _get_nullable_str(data, key):
 
     # We represent a null value as an empty string.
     if isinstance(ep, OverrideNone):
-        ep = OverrideStr('')
+        ep = OverrideStr("")
     elif ep is None:
-        ep = ''
+        ep = ""
 
     if not isinstance(ep, str):
         raise ConfigError(f"{key!r} must be a string, not {type(ep).__name__}")
     return ep
 
+
 def _get_entrypoint(data):
-    return _get_nullable_str(data, 'entrypoint')
+    return _get_nullable_str(data, "entrypoint")
+
 
 def _get_docker_args(data):
-    args = _get_nullable_str(data, 'docker_args')
+    args = _get_nullable_str(data, "docker_args")
 
     if args is not None:
         override = isinstance(args, OverrideMixin)
@@ -238,21 +260,25 @@ def _get_docker_args(data):
 
     return args
 
+
 def _get_typed_val(data, key, type_):
     v = data.get(key)
     if v is not None and not isinstance(v, type_):
         raise ConfigError(f"{key!r} must be a {type_.__name__}, not {type(v).__name__}")
     return v
 
+
 def _get_dict(data, key):
     return _get_typed_val(data, key, dict)
+
 
 def _get_delimited_str_list(data, key, sep):
     s = _get_typed_val(data, key, str)
     return s.split(sep) if s else []
 
+
 def _get_volumes(data):
-    voldata = _get_dict(data, 'volumes')
+    voldata = _get_dict(data, "volumes")
     if voldata is None:
         return None
 
@@ -262,16 +288,22 @@ def _get_volumes(data):
         vols[cpath] = ScubaVolume.from_dict(cpath, v)
     return vols
 
+
 def _expand_path(in_str):
     try:
         output = expand_env_vars(in_str)
     except KeyError as ke:
         # pylint: disable=raise-missing-from
-        raise ConfigError(f"Unset environment variable {ke.args[0]!r} used in {in_str!r}")
+        raise ConfigError(
+            f"Unset environment variable {ke.args[0]!r} used in {in_str!r}"
+        )
     except ValueError as ve:
-        raise ConfigError(f"Unable to expand string '{in_str}' due to parsing errors") from ve
+        raise ConfigError(
+            f"Unable to expand string '{in_str}' due to parsing errors"
+        ) from ve
 
     return output
+
 
 class ScubaVolume:
     def __init__(self, container_path, host_path=None, options=None):
@@ -290,9 +322,9 @@ class ScubaVolume:
         #   /foo: /host/foo
         if isinstance(node, str):
             return cls(
-                container_path = cpath,
-                host_path = _expand_path(node),
-                )
+                container_path=cpath,
+                host_path=_expand_path(node),
+            )
 
         # Complex form
         # volumes:
@@ -300,14 +332,14 @@ class ScubaVolume:
         #     hostpath: /host/foo
         #     options: ro,z
         if isinstance(node, dict):
-            hpath = node.get('hostpath')
+            hpath = node.get("hostpath")
             if hpath is None:
                 raise ConfigError(f"Volume {cpath} must have a 'hostpath' subkey")
             return cls(
-                container_path = cpath,
-                host_path = _expand_path(hpath),
-                options = _get_delimited_str_list(node, 'options', ','),
-                )
+                container_path=cpath,
+                host_path=_expand_path(hpath),
+                options=_get_delimited_str_list(node, "options", ","),
+            )
 
         raise ConfigError(f"{cpath}: must be string or dict")
 
@@ -318,9 +350,18 @@ class ScubaVolume:
 
 
 class ScubaAlias:
-    def __init__(self, name, script, image=None, entrypoint=None,
-            environment=None, shell=None, as_root=None, docker_args=None,
-            volumes=None):
+    def __init__(
+        self,
+        name,
+        script,
+        image=None,
+        entrypoint=None,
+        environment=None,
+        shell=None,
+        as_root=None,
+        docker_args=None,
+        volumes=None,
+    ):
         self.name = name
         self.script = script
         self.image = image
@@ -337,18 +378,18 @@ class ScubaAlias:
 
         if isinstance(node, dict):  # Rich alias
             return cls(
-                name = name,
-                script = script,
-                image = node.get('image'),
-                entrypoint = _get_entrypoint(node),
-                environment = _process_environment(
-                        node.get('environment'),
-                        f"{name}.environment"),
-                shell = node.get('shell'),
-                as_root = node.get('root'),
-                docker_args = _get_docker_args(node),
-                volumes = _get_volumes(node),
-                )
+                name=name,
+                script=script,
+                image=node.get("image"),
+                entrypoint=_get_entrypoint(node),
+                environment=_process_environment(
+                    node.get("environment"), f"{name}.environment"
+                ),
+                shell=node.get("shell"),
+                as_root=node.get("root"),
+                docker_args=_get_docker_args(node),
+                volumes=_get_volumes(node),
+            )
 
         return cls(name=name, script=script)
 
@@ -356,8 +397,14 @@ class ScubaAlias:
 class ScubaConfig:
     def __init__(self, **data):
         optional_nodes = (
-            'image', 'aliases', 'hooks', 'entrypoint', 'environment', 'shell',
-            'docker_args', 'volumes',
+            "image",
+            "aliases",
+            "hooks",
+            "entrypoint",
+            "environment",
+            "shell",
+            "docker_args",
+            "volumes",
         )
 
         # Check for unrecognized nodes
@@ -365,10 +412,11 @@ class ScubaConfig:
         if extra:
             raise ConfigError(
                 f"{SCUBA_YML}: Unrecognized node{'s' if len(extra) > 1 else ''}:"
-                + ', '.join(extra))
+                + ", ".join(extra)
+            )
 
-        self._image = data.get('image')
-        self.shell = data.get('shell', DEFAULT_SHELL)
+        self._image = data.get("image")
+        self.shell = data.get("shell", DEFAULT_SHELL)
         self.entrypoint = _get_entrypoint(data)
         self.docker_args = _get_docker_args(data)
         self.volumes = _get_volumes(data)
@@ -376,27 +424,28 @@ class ScubaConfig:
         self._load_hooks(data)
         self._load_environment(data)
 
-
     def _load_aliases(self, data):
         self.aliases = {}
 
-        for name, node in data.get('aliases', {}).items():
-            if ' ' in name:
-                raise ConfigError('Alias names cannot contain spaces')
+        for name, node in data.get("aliases", {}).items():
+            if " " in name:
+                raise ConfigError("Alias names cannot contain spaces")
             self.aliases[name] = ScubaAlias.from_dict(name, node)
 
     def _load_hooks(self, data):
         self.hooks = {}
 
-        for name in ('user', 'root',):
-            node = data.get('hooks', {}).get(name)
+        for name in (
+            "user",
+            "root",
+        ):
+            node = data.get("hooks", {}).get(name)
             if node:
                 hook = _process_script_node(node, name)
                 self.hooks[name] = hook
 
     def _load_environment(self, data):
-        self.environment = _process_environment(data.get('environment'), 'environment')
-
+        self.environment = _process_environment(data.get("environment"), "environment")
 
     @property
     def image(self):
@@ -405,14 +454,13 @@ class ScubaConfig:
         return self._image
 
 
-
 def load_config(path):
     try:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             data = yaml.load(f, Loader)
     except IOError as e:
-        raise ConfigError(f'Error opening {SCUBA_YML}: {e}')
+        raise ConfigError(f"Error opening {SCUBA_YML}: {e}")
     except yaml.YAMLError as e:
-        raise ConfigError(f'Error loading {SCUBA_YML}: {e}')
+        raise ConfigError(f"Error loading {SCUBA_YML}: {e}")
 
     return ScubaConfig(**(data or {}))

--- a/scuba/constants.py
+++ b/scuba/constants.py
@@ -1,5 +1,5 @@
 # Name of config file to search for and load
-SCUBA_YML = '.scuba.yml'
+SCUBA_YML = ".scuba.yml"
 
 # Default shell to run in the container
-DEFAULT_SHELL = '/bin/sh'
+DEFAULT_SHELL = "/bin/sh"

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -2,35 +2,41 @@ import subprocess
 import errno
 import json
 
+
 class DockerError(Exception):
     pass
 
+
 class DockerExecuteError(DockerError):
     pass
+
 
 class NoSuchImageError(DockerError):
     def __init__(self, image):
         self.image = image
 
     def __str__(self):
-        return f'No such image: {self.image}'
+        return f"No such image: {self.image}"
 
 
 def __wrap_docker_exec(func):
-    '''Wrap a function to raise DockerExecuteError on ENOENT'''
+    """Wrap a function to raise DockerExecuteError on ENOENT"""
+
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except FileNotFoundError:
-            raise DockerExecuteError('Failed to execute docker. Is it installed?')
+            raise DockerExecuteError("Failed to execute docker. Is it installed?")
+
     return wrapper
+
 
 call = __wrap_docker_exec(subprocess.call)
 
 
 def _run_docker(*args, capture=False):
-    '''Run docker and raise DockerExecuteError on ENOENT'''
-    args = ['docker'] + list(args)
+    """Run docker and raise DockerExecuteError on ENOENT"""
+    args = ["docker"] + list(args)
     kw = dict(text=True)
     if capture:
         kw.update(capture_output=True)
@@ -39,28 +45,30 @@ def _run_docker(*args, capture=False):
 
 
 def docker_inspect(image):
-    '''Inspects a docker image
+    """Inspects a docker image
 
     Returns: Parsed JSON data
-    '''
-    cp = _run_docker('inspect', '--type', 'image', image, capture=True)
+    """
+    cp = _run_docker("inspect", "--type", "image", image, capture=True)
 
     if not cp.returncode == 0:
-        if 'no such image' in cp.stderr.lower():
+        if "no such image" in cp.stderr.lower():
             raise NoSuchImageError(image)
-        raise DockerError(f'Failed to inspect image: {cp.stderr.strip()}')
+        raise DockerError(f"Failed to inspect image: {cp.stderr.strip()}")
 
     return json.loads(cp.stdout)[0]
 
+
 def docker_pull(image):
-    '''Pulls an image'''
+    """Pulls an image"""
     # If this fails, the default docker stdout/stderr looks good to the user.
-    cp = _run_docker('pull', image)
+    cp = _run_docker("pull", image)
     if cp.returncode != 0:
-        raise DockerError(f'Failed to pull image: {image}')
+        raise DockerError(f"Failed to pull image: {image}")
+
 
 def docker_inspect_or_pull(image):
-    '''Inspects a docker image, pulling it if it doesn't exist'''
+    """Inspects a docker image, pulling it if it doesn't exist"""
     try:
         return docker_inspect(image)
     except NoSuchImageError:
@@ -70,15 +78,17 @@ def docker_inspect_or_pull(image):
 
 
 def get_images():
-    '''Get the current list of docker images
+    """Get the current list of docker images
 
     Returns: List of image names
-    '''
-    cp = _run_docker('images',
+    """
+    cp = _run_docker(
+        "images",
         # This format ouputs the same thing as '__docker_images --repo --tag'
-        '--format', (
+        "--format",
+        (
             # Always show the bare repository name
-            r'{{.Repository}}'
+            r"{{.Repository}}"
             # And if there is a tag, show that too
             r'{{if ne .Tag "<none>"}}\n{{.Repository}}:{{.Tag}}{{end}}'
         ),
@@ -86,34 +96,34 @@ def get_images():
     )
 
     if not cp.returncode == 0:
-        raise DockerError(f'Failed to retrieve images: {cp.stderr.strip()}')
+        raise DockerError(f"Failed to retrieve images: {cp.stderr.strip()}")
 
     return cp.stdout.splitlines()
 
 
 def get_image_command(image):
-    '''Gets the default command for an image'''
+    """Gets the default command for an image"""
     info = docker_inspect_or_pull(image)
     try:
-        return info['Config']['Cmd']
+        return info["Config"]["Cmd"]
     except KeyError as ke:
-        raise DockerError(f'Failed to inspect image: JSON result missing key {ke}')
+        raise DockerError(f"Failed to inspect image: JSON result missing key {ke}")
+
 
 def get_image_entrypoint(image):
-    '''Gets the image entrypoint'''
+    """Gets the image entrypoint"""
     info = docker_inspect_or_pull(image)
     try:
-        return info['Config']['Entrypoint']
+        return info["Config"]["Entrypoint"]
     except KeyError as ke:
-        raise DockerError(f'Failed to inspect image: JSON result missing key {ke}')
+        raise DockerError(f"Failed to inspect image: JSON result missing key {ke}")
 
 
 def make_vol_opt(hostdir, contdir, options=None):
-    '''Generate a docker volume option'''
-    vol = f'--volume={hostdir}:{contdir}'
+    """Generate a docker volume option"""
+    vol = f"--volume={hostdir}:{contdir}"
     if options != None:
         if isinstance(options, str):
             options = (options,)
-        vol += ':' + ','.join(options)
+        vol += ":" + ",".join(options)
     return vol
-

--- a/scuba/utils.py
+++ b/scuba/utils.py
@@ -5,38 +5,38 @@ import string
 
 
 def shell_quote_cmd(cmdlist):
-    return ' '.join(map(shell_quote, cmdlist))
+    return " ".join(map(shell_quote, cmdlist))
 
 
 def format_cmdline(args, maxwidth=80):
-    '''Format args into a shell-quoted command line.
+    """Format args into a shell-quoted command line.
 
     The result will be wrapped to maxwidth characters where possible,
     not breaking a single long argument.
-    '''
+    """
 
     # Leave room for the space and backslash at the end of each line
     maxwidth -= 2
 
     def lines():
-        line = ''
+        line = ""
         for a in (shell_quote(a) for a in args):
             # If adding this argument will make the line too long,
             # yield the current line, and start a new one.
             if len(line) + len(a) + 1 > maxwidth:
                 yield line
-                line = ''
+                line = ""
 
             # Append this argument to the current line, separating
             # it by a space from the existing arguments.
             if line:
-                line += ' ' + a
+                line += " " + a
             else:
                 line = a
 
         yield line
 
-    return ' \\\n'.join(lines())
+    return " \\\n".join(lines())
 
 
 def parse_env_var(s):
@@ -49,13 +49,13 @@ def parse_env_var(s):
     then the current value of the named variable is propagated into the
     container's environment
     """
-    parts = s.split('=', 1)
+    parts = s.split("=", 1)
     if len(parts) == 2:
         k, v = parts
         return (k, v)
 
     k = parts[0]
-    return (k, os.getenv(k, ''))
+    return (k, os.getenv(k, ""))
 
 
 def flatten_list(x):
@@ -79,7 +79,8 @@ def get_umask():
 
 
 def writeln(f, line):
-    f.write(line + '\n')
+    f.write(line + "\n")
+
 
 def expand_env_vars(in_str):
     """Expand environment variables in a string

--- a/scuba/version.py
+++ b/scuba/version.py
@@ -7,71 +7,70 @@ import sys
 PACKAGEPATH = abspath(dirname(__file__))
 PROJPATH = dirname(PACKAGEPATH)
 
-DIST_SPEC = 'scuba'
+DIST_SPEC = "scuba"
 
 # Base version, which will be augmented with Git information
-BASE_VERSION = '2.10.1'
+BASE_VERSION = "2.10.1"
 
 # This string will be replaced by `git-archive`
 # with the abbreviated commit hash
 git_archive_rev = "$Format:%h$"
 
+
 def git_describe():
     from subprocess import check_call, check_output
 
     # Get the version from the local Git repository
-    check_call(['git', 'update-index', '-q', '--refresh'], cwd=PROJPATH)
+    check_call(["git", "update-index", "-q", "--refresh"], cwd=PROJPATH)
 
-    desc = check_output(['git', 'describe', '--long', '--dirty', '--tag'], cwd=PROJPATH)
-    desc = desc.decode('utf-8').strip()
+    desc = check_output(["git", "describe", "--long", "--dirty", "--tag"], cwd=PROJPATH)
+    desc = desc.decode("utf-8").strip()
 
-    tag, commits, rev = desc.split('-', 2)
-    tag = tag.lstrip('v')
+    tag, commits, rev = desc.split("-", 2)
+    tag = tag.lstrip("v")
     commits = int(commits)
 
     return tag, commits, rev
 
-def get_version():
 
+def get_version():
     # Git repo
     # If a local git repository is present, use `git describe` to provide a rich version
-    gitdir = normpath(join(PROJPATH, '.git'))
+    gitdir = normpath(join(PROJPATH, ".git"))
     if exists(gitdir):
         tag, commits, rev = git_describe()
 
         # Ensure the base version matches the Git tag
         if tag != BASE_VERSION:
-            raise Exception('Git revision different from base version')
+            raise Exception("Git revision different from base version")
 
         # No local version if we're on a tag
-        if commits == 0 and not rev.endswith('dirty'):
+        if commits == 0 and not rev.endswith("dirty"):
             return BASE_VERSION
 
-        return f'{BASE_VERSION}+{commits}-{rev}'
-
+        return f"{BASE_VERSION}+{commits}-{rev}"
 
     # Git archive
     # If this was produced via `git archive`, we'll use the version it provides
-    if not git_archive_rev.startswith('$'):
-        return f'{BASE_VERSION}+g{git_archive_rev}'
-
+    if not git_archive_rev.startswith("$"):
+        return f"{BASE_VERSION}+g{git_archive_rev}"
 
     # Package resource
     # Otherwise, we're either installed (e.g. via pip), or running from
     # an 'sdist' source distribution, and have a local PKG_INFO file.
     import pkg_resources
+
     try:
         return pkg_resources.get_distribution(DIST_SPEC).version
     except pkg_resources.DistributionNotFound:
         pass
 
-
     # This shouldn't be able to happen
-    sys.stderr.write('WARNING: Failed to determine version!\n')
+    sys.stderr.write("WARNING: Failed to determine version!\n")
     return BASE_VERSION
 
 
 __version__ = get_version()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(__version__)

--- a/setup.py
+++ b/setup.py
@@ -1,98 +1,103 @@
 import scuba.version
 from setuptools import setup, Command
 from distutils.command.build import build
-from setuptools.command.sdist import sdist 
+from setuptools.command.sdist import sdist
 from subprocess import check_call
 import os
 
 
 class build_scubainit(Command):
-    description = 'Build scubainit binary'
+    description = "Build scubainit binary"
 
-    user_options=[]
+    user_options = []
+
     def initialize_options(self):
         pass
+
     def finalize_options(self):
         pass
 
     def run(self):
-        check_call(['make'])
+        check_call(["make"])
 
 
 class build_hook(build):
     def run(self):
-        self.run_command('build_scubainit')
+        self.run_command("build_scubainit")
         build.run(self)
+
 
 def read_project_file(path):
     proj_dir = os.path.dirname(__file__)
     path = os.path.join(proj_dir, path)
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         return f.read()
+
 
 ################################################################################
 # Dynamic versioning
 
+
 def get_version():
     # CI builds
     # If CI_VERSION_BUILD_NUMBER is set, append that to the base version
-    build_num = os.getenv('CI_VERSION_BUILD_NUMBER')
+    build_num = os.getenv("CI_VERSION_BUILD_NUMBER")
     if build_num:
-        return f'{scuba.version.BASE_VERSION}.{build_num}'
+        return f"{scuba.version.BASE_VERSION}.{build_num}"
 
     # Otherwise, use the auto-versioning
     return scuba.version.__version__
 
+
 ################################################################################
 
 setup(
-    name = 'scuba',
-    version = get_version(),
-    python_requires='>=3.7',
-    description = 'Simplify use of Docker containers for building software',
-    long_description = read_project_file('README.md'),
-    long_description_content_type = 'text/markdown',
-    classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: MacOS :: MacOS X',
-        'Topic :: Software Development :: Build Tools',
+    name="scuba",
+    version=get_version(),
+    python_requires=">=3.7",
+    description="Simplify use of Docker containers for building software",
+    long_description=read_project_file("README.md"),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Topic :: Software Development :: Build Tools",
     ],
-    license = 'MIT',
-    keywords = 'docker',
-    author = 'Jonathon Reinhart',
-    author_email = 'jonathon.reinhart@gmail.com',
-    url = 'https://github.com/JonathonReinhart/scuba',
-    packages = ['scuba'],
-    package_data = {
-        'scuba': [
-            'scubainit',
+    license="MIT",
+    keywords="docker",
+    author="Jonathon Reinhart",
+    author_email="jonathon.reinhart@gmail.com",
+    url="https://github.com/JonathonReinhart/scuba",
+    packages=["scuba"],
+    package_data={
+        "scuba": [
+            "scubainit",
         ],
     },
-    include_package_data = True,    # https://github.com/pypa/setuptools/issues/1064
-    zip_safe = False,   # http://stackoverflow.com/q/24642788/119527
-    entry_points = {
-        'console_scripts': [
-            'scuba = scuba.__main__:main',
+    include_package_data=True,  # https://github.com/pypa/setuptools/issues/1064
+    zip_safe=False,  # http://stackoverflow.com/q/24642788/119527
+    entry_points={
+        "console_scripts": [
+            "scuba = scuba.__main__:main",
         ]
     },
-    install_requires = [
-        'PyYAML',
+    install_requires=[
+        "PyYAML",
     ],
-    extras_require = {
-        'argcomplete': [
-            'argcomplete>=1.10.1',
+    extras_require={
+        "argcomplete": [
+            "argcomplete>=1.10.1",
         ],
     },
-
     # http://stackoverflow.com/questions/17806485
     # http://stackoverflow.com/questions/21915469
-    cmdclass = {
-        'build_scubainit':  build_scubainit,
-        'build':            build_hook,
+    cmdclass={
+        "build_scubainit": build_scubainit,
+        "build": build_hook,
     },
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-pytest.register_assert_rewrite('tests.utils')
+pytest.register_assert_rewrite("tests.utils")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture
 def in_tmp_path(tmp_path, monkeypatch):
     """Runs a test in a temporary directory provided by the tmp_path fixture"""

--- a/tests/const.py
+++ b/tests/const.py
@@ -7,16 +7,16 @@
 # Requirements:
 # - Must contain /bin/bash (TestMain::test_*shell_override*)
 #
-DOCKER_IMAGE = 'debian:10'
+DOCKER_IMAGE = "debian:10"
 
 # Alternate Docker image
 # This image is used for alternate tests (e.g. pulling) and should be small.
-ALT_DOCKER_IMAGE = 'busybox:latest'
+ALT_DOCKER_IMAGE = "busybox:latest"
 
 
 # Act as an executable for consumption by non-Python things
-if __name__ == '__main__':
+if __name__ == "__main__":
     for name, val in dict(vars()).items():
-        if name.startswith('_'):
+        if name.startswith("_"):
             continue
         print(f'{name}="{val}"')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
- # coding=utf-8
+# coding=utf-8
 from .utils import *
 import pytest
 
@@ -12,80 +12,78 @@ import scuba.config
 
 class TestCommonScriptSchema:
     def test_simple(self):
-        '''Simple form: value is a string'''
-        node = 'foo'
-        result = scuba.config._process_script_node(node, 'dontcare')
-        assert result == ['foo']
+        """Simple form: value is a string"""
+        node = "foo"
+        result = scuba.config._process_script_node(node, "dontcare")
+        assert result == ["foo"]
 
     def test_script_key_string(self):
-        '''Value is a mapping: script is a string'''
+        """Value is a mapping: script is a string"""
         node = dict(
-            script = 'foo',
-            otherkey = 'other',
+            script="foo",
+            otherkey="other",
         )
-        result = scuba.config._process_script_node(node, 'dontcare')
-        assert result == ['foo']
+        result = scuba.config._process_script_node(node, "dontcare")
+        assert result == ["foo"]
 
     def test_script_key_list(self):
-        '''Value is a mapping: script is a list'''
+        """Value is a mapping: script is a list"""
         node = dict(
-            script = [
-                'foo',
-                'bar',
+            script=[
+                "foo",
+                "bar",
             ],
-            otherkey = 'other',
+            otherkey="other",
         )
-        result = scuba.config._process_script_node(node, 'dontcare')
-        assert result == ['foo', 'bar']
+        result = scuba.config._process_script_node(node, "dontcare")
+        assert result == ["foo", "bar"]
 
     def test_script_key_mapping_invalid(self):
-        '''Value is a mapping: script is a mapping (invalid)'''
+        """Value is a mapping: script is a mapping (invalid)"""
         node = dict(
-            script = dict(
-                whatisthis = 'idontknow',
+            script=dict(
+                whatisthis="idontknow",
             ),
         )
         with pytest.raises(scuba.config.ConfigError):
-            scuba.config._process_script_node(node, 'dontcare')
+            scuba.config._process_script_node(node, "dontcare")
 
 
 @pytest.mark.usefixtures("in_tmp_path")
 class TestConfig:
-
     ######################################################################
     # Find config
 
     def test_find_config_cur_dir(self, in_tmp_path):
-        '''find_config can find the config in the current directory'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
+        """find_config can find the config in the current directory"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
 
         path, rel, _ = scuba.config.find_config()
         assert_paths_equal(path, in_tmp_path)
-        assert_paths_equal(rel, '')
-
+        assert_paths_equal(rel, "")
 
     def test_find_config_parent_dir(self, in_tmp_path):
-        '''find_config cuba can find the config in the parent directory'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
+        """find_config cuba can find the config in the parent directory"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
 
-        os.mkdir('subdir')
-        os.chdir('subdir')
+        os.mkdir("subdir")
+        os.chdir("subdir")
 
         # Verify our current working dir
-        assert_paths_equal(os.getcwd(), in_tmp_path.joinpath('subdir'))
+        assert_paths_equal(os.getcwd(), in_tmp_path.joinpath("subdir"))
 
         path, rel, _ = scuba.config.find_config()
         assert_paths_equal(path, in_tmp_path)
-        assert_paths_equal(rel, 'subdir')
+        assert_paths_equal(rel, "subdir")
 
     def test_find_config_way_up(self, in_tmp_path):
-        '''find_config can find the config way up the directory hierarchy'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
+        """find_config can find the config way up the directory hierarchy"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
 
-        subdirs = ['foo', 'bar', 'snap', 'crackle', 'pop']
+        subdirs = ["foo", "bar", "snap", "crackle", "pop"]
 
         for sd in subdirs:
             os.mkdir(sd)
@@ -99,7 +97,7 @@ class TestConfig:
         assert_paths_equal(rel, join(*subdirs))
 
     def test_find_config_nonexist(self):
-        '''find_config raises ConfigError if the config cannot be found'''
+        """find_config raises ConfigError if the config cannot be found"""
         with pytest.raises(scuba.config.ConfigError):
             scuba.config.find_config()
 
@@ -108,189 +106,187 @@ class TestConfig:
 
     def _invalid_config(self, match=None):
         with pytest.raises(scuba.config.ConfigError, match=match) as e:
-            scuba.config.load_config('.scuba.yml')
+            scuba.config.load_config(".scuba.yml")
 
     def test_load_config_no_image(self):
-        '''load_config raises ConfigError if the config is empty and image is referenced'''
-        with open('.scuba.yml', 'w') as f:
+        """load_config raises ConfigError if the config is empty and image is referenced"""
+        with open(".scuba.yml", "w") as f:
             pass
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         with pytest.raises(scuba.config.ConfigError):
             img = config.image
 
     def test_load_unexpected_node(self):
-        '''load_config raises ConfigError on unexpected config node'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
-            f.write('unexpected_node_123456: value\n')
+        """load_config raises ConfigError on unexpected config node"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
+            f.write("unexpected_node_123456: value\n")
 
         self._invalid_config()
 
     def test_load_config_minimal(self):
-        '''load_config loads a minimal config'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
+        """load_config loads a minimal config"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == 'bosybux'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "bosybux"
 
     def test_load_config_with_aliases(self):
-        '''load_config loads a config with aliases'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
-            f.write('aliases:\n')
-            f.write('  foo: bar\n')
-            f.write('  snap: crackle pop\n')
+        """load_config loads a config with aliases"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
+            f.write("aliases:\n")
+            f.write("  foo: bar\n")
+            f.write("  snap: crackle pop\n")
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == 'bosybux'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "bosybux"
         assert len(config.aliases) == 2
-        assert config.aliases['foo'].script == ['bar']
-        assert config.aliases['snap'].script == ['crackle pop']
+        assert config.aliases["foo"].script == ["bar"]
+        assert config.aliases["snap"].script == ["crackle pop"]
 
     def test_load_config__no_spaces_in_aliases(self):
-        '''load_config refuses spaces in aliases'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: bosybux\n')
-            f.write('aliases:\n')
-            f.write('  this has spaces: whatever\n')
+        """load_config refuses spaces in aliases"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: bosybux\n")
+            f.write("aliases:\n")
+            f.write("  this has spaces: whatever\n")
 
         self._invalid_config()
 
     def test_load_config_image_from_yaml(self):
-        '''load_config loads a config using !from_yaml'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('image: dummian:8.2\n')
+        """load_config loads a config using !from_yaml"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("image: dummian:8.2\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml image\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml image\n")
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == 'dummian:8.2'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "dummian:8.2"
 
     def test_load_config_image_from_yaml_nested_keys(self):
-        '''load_config loads a config using !from_yaml with nested keys'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('somewhere:\n')
-            f.write('  down:\n')
-            f.write('    here: dummian:8.2\n')
+        """load_config loads a config using !from_yaml with nested keys"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("somewhere:\n")
+            f.write("  down:\n")
+            f.write("    here: dummian:8.2\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml somewhere.down.here\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml somewhere.down.here\n")
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == 'dummian:8.2'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "dummian:8.2"
 
     def test_load_config_image_from_yaml_nested_keys_with_escaped_characters(self):
-        '''load_config loads a config using !from_yaml with nested keys containing escaped '.' characters'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('.its:\n')
-            f.write('  somewhere.down:\n')
-            f.write('    here: dummian:8.2\n')
+        """load_config loads a config using !from_yaml with nested keys containing escaped '.' characters"""
+        with open(".gitlab.yml", "w") as f:
+            f.write(".its:\n")
+            f.write("  somewhere.down:\n")
+            f.write("    here: dummian:8.2\n")
 
-        with open('.scuba.yml', 'w') as f:
+        with open(".scuba.yml", "w") as f:
             f.write('image: !from_yaml .gitlab.yml "\\.its.somewhere\\.down.here"\n')
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == 'dummian:8.2'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "dummian:8.2"
 
     def test_load_config_from_yaml_cached_file(self):
-        '''load_config loads a config using !from_yaml from cached version'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('one: dummian:8.2\n')
-            f.write('two: dummian:9.3\n')
-            f.write('three: dummian:10.1\n')
+        """load_config loads a config using !from_yaml from cached version"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("one: dummian:8.2\n")
+            f.write("two: dummian:9.3\n")
+            f.write("three: dummian:10.1\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml one\n')
-            f.write('aliases:\n')
-            f.write('  two:\n')
-            f.write('    image:  !from_yaml .gitlab.yml two\n')
-            f.write('    script: ugh\n')
-            f.write('  three:\n')
-            f.write('    image:  !from_yaml .gitlab.yml three\n')
-            f.write('    script: ugh\n')
-
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml one\n")
+            f.write("aliases:\n")
+            f.write("  two:\n")
+            f.write("    image:  !from_yaml .gitlab.yml two\n")
+            f.write("    script: ugh\n")
+            f.write("  three:\n")
+            f.write("    image:  !from_yaml .gitlab.yml three\n")
+            f.write("    script: ugh\n")
 
         with mock_open() as m:
-            config = scuba.config.load_config('.scuba.yml')
+            config = scuba.config.load_config(".scuba.yml")
 
         # Assert that .gitlab.yml was only opened once
         assert m.mock_calls == [
-            mock.call('.scuba.yml', 'r'),
-            mock.call('.gitlab.yml', 'r'),
+            mock.call(".scuba.yml", "r"),
+            mock.call(".gitlab.yml", "r"),
         ]
 
     def test_load_config_image_from_yaml_nested_key_missing(self):
-        '''load_config raises ConfigError when !from_yaml references nonexistant key'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('somewhere:\n')
-            f.write('  down:\n')
+        """load_config raises ConfigError when !from_yaml references nonexistant key"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("somewhere:\n")
+            f.write("  down:\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml somewhere.NONEXISTANT\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml somewhere.NONEXISTANT\n")
 
         self._invalid_config()
 
     def test_load_config_image_from_yaml_missing_file(self):
-        '''load_config raises ConfigError when !from_yaml references nonexistant file'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .NONEXISTANT.yml image\n')
+        """load_config raises ConfigError when !from_yaml references nonexistant file"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .NONEXISTANT.yml image\n")
 
         self._invalid_config()
 
     def test_load_config_image_from_yaml_unicode_args(self):
-        '''load_config !from_yaml works with unicode args'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('𝕦𝕟𝕚𝕔𝕠𝕕𝕖: 𝕨𝕠𝕣𝕜𝕤:𝕠𝕜\n')
+        """load_config !from_yaml works with unicode args"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("𝕦𝕟𝕚𝕔𝕠𝕕𝕖: 𝕨𝕠𝕣𝕜𝕤:𝕠𝕜\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml 𝕦𝕟𝕚𝕔𝕠𝕕𝕖\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml 𝕦𝕟𝕚𝕔𝕠𝕕𝕖\n")
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.image == '𝕨𝕠𝕣𝕜𝕤:𝕠𝕜'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.image == "𝕨𝕠𝕣𝕜𝕤:𝕠𝕜"
 
     def test_load_config_image_from_yaml_missing_arg(self):
-        '''load_config raises ConfigError when !from_yaml has missing args'''
-        with open('.gitlab.yml', 'w') as f:
-            f.write('image: dummian:8.2\n')
+        """load_config raises ConfigError when !from_yaml has missing args"""
+        with open(".gitlab.yml", "w") as f:
+            f.write("image: dummian:8.2\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .gitlab.yml\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .gitlab.yml\n")
 
         self._invalid_config()
 
-
     def __test_load_config_safe(self, bad_yaml_path):
-        with open(bad_yaml_path, 'w') as f:
-            f.write('danger:\n')
-            f.write('  - !!python/object/apply:print [Danger]\n')
-            f.write('  - !!python/object/apply:sys.exit [66]\n')
+        with open(bad_yaml_path, "w") as f:
+            f.write("danger:\n")
+            f.write("  - !!python/object/apply:print [Danger]\n")
+            f.write("  - !!python/object/apply:sys.exit [66]\n")
 
         pat = "could not determine a constructor for the tag.*python/object/apply"
         with pytest.raises(scuba.config.ConfigError, match=pat) as ctx:
-            scuba.config.load_config('.scuba.yml')
+            scuba.config.load_config(".scuba.yml")
 
     def test_load_config_safe(self):
-        '''load_config safely loads yaml'''
-        self.__test_load_config_safe('.scuba.yml')
+        """load_config safely loads yaml"""
+        self.__test_load_config_safe(".scuba.yml")
 
     def test_load_config_safe_external(self):
-        '''load_config safely loads yaml from external files'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: !from_yaml .external.yml danger\n')
+        """load_config safely loads yaml from external files"""
+        with open(".scuba.yml", "w") as f:
+            f.write("image: !from_yaml .external.yml danger\n")
 
-        self.__test_load_config_safe('.external.yml')
-
+        self.__test_load_config_safe(".external.yml")
 
     ############################################################################
     # Hooks
 
     def test_hooks_mixed(self):
-        '''hooks of mixed forms are valid'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """hooks of mixed forms are valid"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: na
                 hooks:
                   root:
@@ -298,55 +294,65 @@ class TestConfig:
                       - echo "This runs before we switch users"
                       - id
                   user: id
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
 
-        assert config.hooks.get('root') == ['echo "This runs before we switch users"', 'id']
-        assert config.hooks.get('user') == ['id']
+        assert config.hooks.get("root") == [
+            'echo "This runs before we switch users"',
+            "id",
+        ]
+        assert config.hooks.get("user") == ["id"]
 
     def test_hooks_invalid_list(self):
-        '''hooks with list not under "script" key are invalid'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """hooks with list not under "script" key are invalid"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: na
                 hooks:
                   user:
                     - this list should be under
                     - a 'script'
-                ''')
+                """
+            )
 
         self._invalid_config()
 
     def test_hooks_missing_script(self):
-        '''hooks with dict, but missing "script" are invalid'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """hooks with dict, but missing "script" are invalid"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: na
                 hooks:
                   user:
                     not_script: missing "script" key
-                ''')
+                """
+            )
 
         self._invalid_config()
-
 
     ############################################################################
     # Env
 
     def test_env_invalid(self):
-        '''Environment must be dict or list of strings'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Environment must be dict or list of strings"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 environment: 666
-                ''')
-        self._invalid_config('must be list or mapping')
+                """
+            )
+        self._invalid_config("must be list or mapping")
 
     def test_env_top_dict(self, monkeypatch):
-        '''Top-level environment can be loaded (dict)'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Top-level environment can be loaded (dict)"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 environment:
                   FOO: This is foo
@@ -358,31 +364,32 @@ class TestConfig:
                   EMPTY: ""
                   EXTERNAL:             # Comes from os env
                   EXTERNAL_NOTSET:      # Missing in os env
-                ''')
+                """
+            )
 
-        monkeypatch.setenv('EXTERNAL', 'Outside world')
-        monkeypatch.delenv('EXTERNAL_NOTSET', raising=False)
+        monkeypatch.setenv("EXTERNAL", "Outside world")
+        monkeypatch.delenv("EXTERNAL_NOTSET", raising=False)
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
 
         expect = dict(
-            FOO = "This is foo",
-            FOO_WITH_QUOTES = "\"Quoted foo\"",
-            BAR = "This is bar",
-            MAGIC = "42",           # N.B. string
-            SWITCH_1 = "True",      # Unfortunately this is due to str(bool(1))
-            SWITCH_2 = "true",
-            EMPTY = "",
-            EXTERNAL = "Outside world",
-            EXTERNAL_NOTSET = "",
+            FOO="This is foo",
+            FOO_WITH_QUOTES='"Quoted foo"',
+            BAR="This is bar",
+            MAGIC="42",  # N.B. string
+            SWITCH_1="True",  # Unfortunately this is due to str(bool(1))
+            SWITCH_2="true",
+            EMPTY="",
+            EXTERNAL="Outside world",
+            EXTERNAL_NOTSET="",
         )
         assert expect == config.environment
 
-
     def test_env_top_list(self, monkeypatch):
-        '''Top-level environment can be loaded (list)'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Top-level environment can be loaded (list)"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 environment:
                   - FOO=This is foo                 # No quotes
@@ -393,30 +400,31 @@ class TestConfig:
                   - EMPTY=
                   - EXTERNAL                        # Comes from os env
                   - EXTERNAL_NOTSET                 # Missing in os env
-                ''')
+                """
+            )
 
-        monkeypatch.setenv('EXTERNAL', 'Outside world')
-        monkeypatch.delenv('EXTERNAL_NOTSET', raising=False)
+        monkeypatch.setenv("EXTERNAL", "Outside world")
+        monkeypatch.delenv("EXTERNAL_NOTSET", raising=False)
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
 
         expect = dict(
-            FOO = "This is foo",
-            FOO_WITH_QUOTES = "\"Quoted foo\"",
-            BAR = "This is bar",
-            MAGIC = "42",           # N.B. string
-            SWITCH_2 = "true",
-            EMPTY = "",
-            EXTERNAL = "Outside world",
-            EXTERNAL_NOTSET = "",
+            FOO="This is foo",
+            FOO_WITH_QUOTES='"Quoted foo"',
+            BAR="This is bar",
+            MAGIC="42",  # N.B. string
+            SWITCH_2="true",
+            EMPTY="",
+            EXTERNAL="Outside world",
+            EXTERNAL_NOTSET="",
         )
         assert expect == config.environment
 
-
     def test_env_alias(self):
-        '''Alias can have environment'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Alias can have environment"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 aliases:
                   al:
@@ -424,76 +432,87 @@ class TestConfig:
                     environment:
                       FOO: Overridden
                       MORE: Hello world
-                ''')
-
-        config = scuba.config.load_config('.scuba.yml')
-
-        assert config.aliases['al'].environment == dict(
-                FOO = "Overridden",
-                MORE = "Hello world",
+                """
             )
 
+        config = scuba.config.load_config(".scuba.yml")
+
+        assert config.aliases["al"].environment == dict(
+            FOO="Overridden",
+            MORE="Hello world",
+        )
 
     ############################################################################
     # Entrypoint
 
     def test_entrypoint_not_set(self):
-        '''Entrypoint can be missing'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be missing"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.entrypoint is None
 
     def test_entrypoint_null(self):
-        '''Entrypoint can be set to null'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set to null"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint:
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.entrypoint == ''     # Null => empty string
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.entrypoint == ""  # Null => empty string
 
     def test_entrypoint_invalid(self):
-        '''Entrypoint of incorrect type raises ConfigError'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint of incorrect type raises ConfigError"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: 666
-                ''')
+                """
+            )
 
-        self._invalid_config('must be a string')
+        self._invalid_config("must be a string")
 
     def test_entrypoint_emptry_string(self):
-        '''Entrypoint can be set to an empty string'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set to an empty string"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: ""
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.entrypoint == ''
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.entrypoint == ""
 
     def test_entrypoint_set(self):
-        '''Entrypoint can be set'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: my_ep
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.entrypoint == 'my_ep'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.entrypoint == "my_ep"
 
     def test_alias_entrypoint_null(self):
-        '''Entrypoint can be set to null via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set to null via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: na_ep
                 aliases:
@@ -501,15 +520,17 @@ class TestConfig:
                     entrypoint:
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].entrypoint == ''    # Null => empty string
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].entrypoint == ""  # Null => empty string
 
     def test_alias_entrypoint_empty_string(self):
-        '''Entrypoint can be set to an empty string via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set to an empty string via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: na_ep
                 aliases:
@@ -517,15 +538,17 @@ class TestConfig:
                     entrypoint: ""
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].entrypoint == ''
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].entrypoint == ""
 
     def test_alias_entrypoint(self):
-        '''Entrypoint can be set via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """Entrypoint can be set via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 entrypoint: na_ep
                 aliases:
@@ -533,82 +556,96 @@ class TestConfig:
                     entrypoint: use_this_ep
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].entrypoint == 'use_this_ep'
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].entrypoint == "use_this_ep"
 
     ############################################################################
     # docker_args
 
     def test_docker_args_not_set(self):
-        '''docker_args can be missing'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be missing"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.docker_args is None
 
     def test_docker_args_invalid(self):
-        '''docker_args of incorrect type raises ConfigError'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args of incorrect type raises ConfigError"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: 666
-                ''')
+                """
+            )
 
-        self._invalid_config('must be a string')
+        self._invalid_config("must be a string")
 
     def test_docker_args_null(self):
-        '''docker_args can be set to null'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set to null"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args:
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.docker_args == []
 
     def test_docker_args_set_empty_string(self):
-        '''docker_args can be set to empty string'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set to empty string"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: ''
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.docker_args == []  # '' -> [] after shlex.split()
 
     def test_docker_args_set(self):
-        '''docker_args can be set'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.docker_args == ['--privileged']
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.docker_args == ["--privileged"]
 
     def test_docker_args_set_multi(self):
-        '''docker_args can be set to multiple args'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set to multiple args"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged -v /tmp/:/tmp/
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.docker_args == ['--privileged', '-v', '/tmp/:/tmp/']
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.docker_args == ["--privileged", "-v", "/tmp/:/tmp/"]
 
     def test_alias_docker_args_null(self):
-        '''docker_args can be set to null via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set to null via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -616,15 +653,17 @@ class TestConfig:
                     docker_args:
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == []
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == []
 
     def test_alias_docker_args_empty_string(self):
-        '''docker_args can be set to empty string via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set to empty string via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -632,15 +671,17 @@ class TestConfig:
                     docker_args: ''
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == []
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == []
 
     def test_alias_docker_args_set(self):
-        '''docker_args can be set via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -648,15 +689,17 @@ class TestConfig:
                     docker_args: -v /tmp/:/tmp/
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == ['-v', '/tmp/:/tmp/']
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
 
     def test_alias_docker_args_override(self):
-        '''docker_args can be tagged for override'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be tagged for override"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -664,16 +707,20 @@ class TestConfig:
                     docker_args: !override -v /tmp/:/tmp/
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == ['-v', '/tmp/:/tmp/']
-        assert isinstance(config.aliases['testalias'].docker_args, scuba.config.OverrideMixin)
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
+        assert isinstance(
+            config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
+        )
 
     def test_alias_docker_args_override_implicit_null(self):
-        '''docker_args can be overridden with an implicit null value'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be overridden with an implicit null value"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -681,19 +728,23 @@ class TestConfig:
                     docker_args: !override
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == []
-        assert isinstance(config.aliases['testalias'].docker_args, scuba.config.OverrideMixin)
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == []
+        assert isinstance(
+            config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
+        )
 
     def test_alias_docker_args_override_from_yaml(self):
-        '''!override tag can be applied before a !from_yaml tag'''
-        with open('args.yml', 'w') as f:
-            f.write('args: -v /tmp/:/tmp/\n')
+        """!override tag can be applied before a !from_yaml tag"""
+        with open("args.yml", "w") as f:
+            f.write("args: -v /tmp/:/tmp/\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -701,19 +752,23 @@ class TestConfig:
                     docker_args: !override '!from_yaml args.yml args'
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == ['-v', '/tmp/:/tmp/']
-        assert isinstance(config.aliases['testalias'].docker_args, scuba.config.OverrideMixin)
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
+        assert isinstance(
+            config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
+        )
 
     def test_alias_docker_args_from_yaml_override(self):
-        '''!override tag can be applied inside of a !from_yaml tag'''
-        with open('args.yml', 'w') as f:
-            f.write('args: !override -v /tmp/:/tmp/\n')
+        """!override tag can be applied inside of a !from_yaml tag"""
+        with open("args.yml", "w") as f:
+            f.write("args: !override -v /tmp/:/tmp/\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 docker_args: --privileged
                 aliases:
@@ -721,105 +776,123 @@ class TestConfig:
                     docker_args: !from_yaml args.yml args
                     script:
                       - ugh
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        assert config.aliases['testalias'].docker_args == ['-v', '/tmp/:/tmp/']
-        assert isinstance(config.aliases['testalias'].docker_args, scuba.config.OverrideMixin)
+        config = scuba.config.load_config(".scuba.yml")
+        assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
+        assert isinstance(
+            config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
+        )
 
     ############################################################################
     # volumes
 
     def test_volumes_not_set(self):
-        '''volumes can be missing'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volumes can be missing"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.volumes is None
 
     def test_volumes_null(self):
-        '''volumes can be set to null'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volumes can be set to null"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert config.volumes == None
 
     def test_volumes_invalid(self):
-        '''volumes of incorrect type raises ConfigError'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volumes of incorrect type raises ConfigError"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes: 666
-                ''')
+                """
+            )
 
-        self._invalid_config('must be a dict')
+        self._invalid_config("must be a dict")
 
     def test_volumes_invalid_volume_type(self):
-        '''volume of incorrect type (list) raises ConfigError'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volume of incorrect type (list) raises ConfigError"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   /foo:
                     - a list makes no sense
-                ''')
+                """
+            )
 
-        self._invalid_config('must be string or dict')
+        self._invalid_config("must be string or dict")
 
     def test_volumes_null_volume_type(self):
-        '''volume of None type raises ConfigError'''
+        """volume of None type raises ConfigError"""
         # NOTE: In the future, we might want to support this as a volume
         #       (non-bindmount, e.g. '-v /somedata'), or as tmpfs
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   /bar:
-                ''')
+                """
+            )
 
-        self._invalid_config('hostpath')
+        self._invalid_config("hostpath")
 
     def test_volume_as_dict_missing_hostpath(self):
-        '''volume of incorrect type raises ConfigError'''
+        """volume of incorrect type raises ConfigError"""
         # NOTE: In the future, we might want to support this as a volume
         #       (non-bindmount, e.g. '-v /somedata'), or as tmpfs
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   /bar:
                     options: hostpath,is,missing
-                ''')
+                """
+            )
 
-        self._invalid_config('hostpath')
+        self._invalid_config("hostpath")
 
     def test_volumes_simple_volume(self):
-        '''volumes can be set using the simple form'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volumes can be set using the simple form"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   /cpath: /hpath
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         assert len(config.volumes) == 1
 
-        v = config.volumes['/cpath']
-        assert v.container_path == '/cpath'
-        assert v.host_path == '/hpath'
+        v = config.volumes["/cpath"]
+        assert v.container_path == "/cpath"
+        assert v.host_path == "/hpath"
 
     def test_volumes_complex(self):
-        '''volumes can be set using the complex form'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """volumes can be set using the complex form"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   /foo: /host/foo
@@ -828,34 +901,36 @@ class TestConfig:
                   /snap:
                     hostpath: /host/snap
                     options: z,ro
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         vols = config.volumes
         assert len(vols) == 3
 
-        v = vols['/foo']
+        v = vols["/foo"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/foo'
-        assert v.host_path == '/host/foo'
+        assert v.container_path == "/foo"
+        assert v.host_path == "/host/foo"
         assert v.options == []
 
-        v = vols['/bar']
+        v = vols["/bar"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/bar'
-        assert v.host_path == '/host/bar'
+        assert v.container_path == "/bar"
+        assert v.host_path == "/host/bar"
         assert v.options == []
 
-        v = vols['/snap']
+        v = vols["/snap"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/snap'
-        assert v.host_path == '/host/snap'
-        assert v.options == ['z', 'ro']
+        assert v.container_path == "/snap"
+        assert v.host_path == "/host/snap"
+        assert v.options == ["z", "ro"]
 
     def test_alias_volumes_set(self):
-        '''docker_args can be set via alias'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        """docker_args can be set via alias"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 aliases:
                   testalias:
@@ -866,53 +941,57 @@ class TestConfig:
                       /bar:
                         hostpath: /host/bar
                         options: z,ro
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
-        vols = config.aliases['testalias'].volumes
+        config = scuba.config.load_config(".scuba.yml")
+        vols = config.aliases["testalias"].volumes
         assert len(vols) == 2
 
-        v = vols['/foo']
+        v = vols["/foo"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/foo'
-        assert v.host_path == '/host/foo'
+        assert v.container_path == "/foo"
+        assert v.host_path == "/host/foo"
         assert v.options == []
 
-        v = vols['/bar']
+        v = vols["/bar"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/bar'
-        assert v.host_path == '/host/bar'
-        assert v.options == ['z', 'ro']
+        assert v.container_path == "/bar"
+        assert v.host_path == "/host/bar"
+        assert v.options == ["z", "ro"]
 
     def test_volumes_with_env_vars_simple(self, monkeypatch):
-        '''volume definitions can contain environment variables'''
+        """volume definitions can contain environment variables"""
         monkeypatch.setenv("TEST_VOL_PATH", "/bar/baz")
         monkeypatch.setenv("TEST_VOL_PATH2", "/moo/doo")
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   $TEST_VOL_PATH/foo: ${TEST_VOL_PATH2}/foo
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         vols = config.volumes
         assert len(vols) == 1
 
         v = list(vols.values())[0]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/bar/baz/foo'
-        assert v.host_path == '/moo/doo/foo'
+        assert v.container_path == "/bar/baz/foo"
+        assert v.host_path == "/moo/doo/foo"
         assert v.options == []
 
     def test_volumes_with_env_vars_complex(self, monkeypatch):
-        '''complex volume definitions can contain environment variables'''
+        """complex volume definitions can contain environment variables"""
         monkeypatch.setenv("TEST_HOME", "/home/testuser")
         monkeypatch.setenv("TEST_TMP", "/tmp")
         monkeypatch.setenv("TEST_MAIL", "/var/spool/mail/testuser")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   $TEST_HOME/.config: ${TEST_HOME}/.config
@@ -921,38 +1000,41 @@ class TestConfig:
                   /var/spool/mail/container:
                     hostpath: $TEST_MAIL
                     options: z,ro
-                ''')
+                """
+            )
 
-        config = scuba.config.load_config('.scuba.yml')
+        config = scuba.config.load_config(".scuba.yml")
         vols = config.volumes
         assert len(vols) == 3
 
-        v = vols['/home/testuser/.config']
+        v = vols["/home/testuser/.config"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/home/testuser/.config'
-        assert v.host_path == '/home/testuser/.config'
+        assert v.container_path == "/home/testuser/.config"
+        assert v.host_path == "/home/testuser/.config"
         assert v.options == []
 
-        v = vols['/tmp/']
+        v = vols["/tmp/"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/tmp/'
-        assert v.host_path == '/home/testuser/scuba/myproject/tmp'
+        assert v.container_path == "/tmp/"
+        assert v.host_path == "/home/testuser/scuba/myproject/tmp"
         assert v.options == []
 
-        v = vols['/var/spool/mail/container']
+        v = vols["/var/spool/mail/container"]
         assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == '/var/spool/mail/container'
+        assert v.container_path == "/var/spool/mail/container"
         assert v.host_path == "/var/spool/mail/testuser"
-        assert v.options == ['z', 'ro']
+        assert v.options == ["z", "ro"]
 
     def test_volumes_with_invalid_env_vars(self, monkeypatch):
-        '''Volume definitions cannot include unset env vars'''
+        """Volume definitions cannot include unset env vars"""
         # Ensure that the entry does not exist in the environment
         monkeypatch.delenv("TEST_VAR1", raising=False)
-        with open('.scuba.yml', 'w') as f:
-            f.write(r'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
                 image: na
                 volumes:
                   $TEST_VAR1/foo: /host/foo
-                ''')
-        self._invalid_config('TEST_VAR1')
+                """
+            )
+        self._invalid_config("TEST_VAR1")

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -1,4 +1,4 @@
- # coding=utf-8
+# coding=utf-8
 from unittest import mock
 import pytest
 
@@ -7,26 +7,29 @@ from .const import *
 
 import scuba.dockerutil as uut
 
+
 def test_get_image_command_success():
-    '''get_image_command works'''
+    """get_image_command works"""
     assert uut.get_image_command(DOCKER_IMAGE)
 
+
 def test_get_image_command_bad_image():
-    '''get_image_command raises an exception for a bad image name'''
+    """get_image_command raises an exception for a bad image name"""
     with pytest.raises(uut.DockerError):
-        uut.get_image_command('nosuchimageZZZZZZZZ')
+        uut.get_image_command("nosuchimageZZZZZZZZ")
+
 
 def test_get_image_no_docker():
-    '''get_image_command raises an exception if docker is not installed'''
+    """get_image_command raises an exception if docker is not installed"""
 
     def mocked_run(args, real_run=subprocess.run, **kw):
-        assert args[0] == 'docker'
-        args[0] = 'dockerZZZZ'
+        assert args[0] == "docker"
+        args[0] = "dockerZZZZ"
         return real_run(args, **kw)
 
-    with mock.patch('subprocess.run', side_effect=mocked_run) as run_mock:
+    with mock.patch("subprocess.run", side_effect=mocked_run) as run_mock:
         with pytest.raises(uut.DockerError):
-            uut.get_image_command('n/a')
+            uut.get_image_command("n/a")
 
 
 def _test_get_images(stdout, returncode=0):
@@ -36,18 +39,19 @@ def _test_get_images(stdout, returncode=0):
         mock_obj.stdout = stdout
         return mock_obj
 
-    with mock.patch('subprocess.run', side_effect=mocked_run) as run_mock:
+    with mock.patch("subprocess.run", side_effect=mocked_run) as run_mock:
         return uut.get_images()
 
 
 def test_get_images_success__no_images():
-    '''get_images works when no images are present'''
-    images = _test_get_images('')
+    """get_images works when no images are present"""
+    images = _test_get_images("")
     assert images == []
 
+
 def test_get_images_success__multiple_images():
-    '''get_images works when many images are present'''
-    output = '''\
+    """get_images works when many images are present"""
+    output = """\
 foo
 foo:latest
 bar
@@ -55,30 +59,31 @@ bar:snap
 bar:latest
 dummy/crackle
 dummy/crackle:pop
-'''
+"""
     images = _test_get_images(output)
     assert images == [
-                'foo',
-                'foo:latest',
-                'bar',
-                'bar:snap',
-                'bar:latest',
-                'dummy/crackle',
-                'dummy/crackle:pop',
-            ]
+        "foo",
+        "foo:latest",
+        "bar",
+        "bar:snap",
+        "bar:latest",
+        "dummy/crackle",
+        "dummy/crackle:pop",
+    ]
+
 
 def test_get_images__failure():
-    '''get_images fails because of error'''
+    """get_images fails because of error"""
     with pytest.raises(uut.DockerError):
-        _test_get_images('This is a pre-canned error', 1)
+        _test_get_images("This is a pre-canned error", 1)
 
 
 def test__get_image_command__pulls_image_if_missing():
-    '''get_image_command pulls an image if missing'''
+    """get_image_command pulls an image if missing"""
     image = ALT_DOCKER_IMAGE
 
     # First remove the image
-    subprocess.call(['docker', 'rmi', image])
+    subprocess.call(["docker", "rmi", image])
 
     # Now try to get the image's Command
     result = uut.get_image_command(image)
@@ -86,22 +91,32 @@ def test__get_image_command__pulls_image_if_missing():
     # Should return a non-empty string
     assert result
 
+
 def test_get_image_entrypoint():
-    '''get_image_entrypoint works'''
-    result = uut.get_image_entrypoint('scuba/entrypoint-test')
-    assert result == ['/entrypoint.sh']
+    """get_image_entrypoint works"""
+    result = uut.get_image_entrypoint("scuba/entrypoint-test")
+    assert result == ["/entrypoint.sh"]
+
 
 def test_get_image_entrypoint__none():
-    '''get_image_entrypoint works for image with no entrypoint'''
+    """get_image_entrypoint works for image with no entrypoint"""
     result = uut.get_image_entrypoint(DOCKER_IMAGE)
     assert result is None
 
 
 def test_make_vol_opt_no_opts():
-    assert uut.make_vol_opt('/hostdir', '/contdir') == '--volume=/hostdir:/contdir'
+    assert uut.make_vol_opt("/hostdir", "/contdir") == "--volume=/hostdir:/contdir"
+
 
 def test_make_vol_opt_one_opt():
-    assert uut.make_vol_opt('/hostdir', '/contdir', 'ro') == '--volume=/hostdir:/contdir:ro'
+    assert (
+        uut.make_vol_opt("/hostdir", "/contdir", "ro")
+        == "--volume=/hostdir:/contdir:ro"
+    )
+
 
 def test_make_vol_opt_multi_opts():
-    assert uut.make_vol_opt('/hostdir', '/contdir', ['ro', 'z']) == '--volume=/hostdir:/contdir:ro,z'
+    assert (
+        uut.make_vol_opt("/hostdir", "/contdir", ["ro", "z"])
+        == "--volume=/hostdir:/contdir:ro,z"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,42 +23,42 @@ from .const import DOCKER_IMAGE
 
 SCUBAINIT_EXIT_FAIL = 99
 
+
 @pytest.mark.usefixtures("in_tmp_path")
 class TestMain:
-
     def run_scuba(self, args, exp_retval=0, mock_isatty=False, stdin=None):
-        '''Run scuba, checking its return value
+        """Run scuba, checking its return value
 
         Returns scuba/docker stdout data.
-        '''
+        """
 
         # Capture both scuba and docker's stdout/stderr,
         # just as the user would see it.
-        with TemporaryFile(prefix='scubatest-stdout', mode='w+t') as stdout:
-            with TemporaryFile(prefix='scubatest-stderr', mode='w+t') as stderr:
+        with TemporaryFile(prefix="scubatest-stdout", mode="w+t") as stdout:
+            with TemporaryFile(prefix="scubatest-stderr", mode="w+t") as stderr:
                 if mock_isatty:
                     stdout = PseudoTTY(stdout)
                     stderr = PseudoTTY(stderr)
 
-                old_stdin  = sys.stdin
+                old_stdin = sys.stdin
                 old_stdout = sys.stdout
                 old_stderr = sys.stderr
 
                 if stdin is None:
-                    sys.stdin = open(os.devnull, 'w')
+                    sys.stdin = open(os.devnull, "w")
                 else:
                     sys.stdin = stdin
                 sys.stdout = stdout
                 sys.stderr = stderr
 
                 try:
-                    '''
+                    """
                     Call scuba's main(), and expect it to either exit()
                     with a given return code, or return (implying an exit
                     status of 0).
-                    '''
+                    """
                     try:
-                        main.main(argv = args)
+                        main.main(argv=args)
                     except SystemExit as sysexit:
                         retcode = sysexit.code
                     else:
@@ -70,8 +70,8 @@ class TestMain:
                     stdout_data = stdout.read()
                     stderr_data = stderr.read()
 
-                    logging.info('scuba stdout:\n' + stdout_data)
-                    logging.info('scuba stderr:\n' + stderr_data)
+                    logging.info("scuba stdout:\n" + stdout_data)
+                    logging.info("scuba stderr:\n" + stderr_data)
 
                     # Verify the return value was as expected
                     assert exp_retval == retcode
@@ -79,69 +79,68 @@ class TestMain:
                     return stdout_data, stderr_data
 
                 finally:
-                    sys.stdin  = old_stdin
+                    sys.stdin = old_stdin
                     sys.stdout = old_stdout
                     sys.stderr = old_stderr
 
-
     def test_basic(self):
-        '''Verify basic scuba functionality'''
+        """Verify basic scuba functionality"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        args = ['/bin/echo', '-n', 'my output']
+        args = ["/bin/echo", "-n", "my output"]
         out, _ = self.run_scuba(args)
 
-        assert_str_equalish('my output', out)
+        assert_str_equalish("my output", out)
 
     def test_no_cmd(self):
-        '''Verify scuba works with no given command'''
+        """Verify scuba works with no given command"""
 
-        with open('.scuba.yml', 'w') as f:
+        with open(".scuba.yml", "w") as f:
             f.write("image: scuba/hello\n")
 
         out, _ = self.run_scuba([])
-        assert_str_equalish(out, 'Hello world')
+        assert_str_equalish(out, "Hello world")
 
     def test_no_image_cmd(self):
-        '''Verify scuba gracefully handles an image with no Cmd and no user command'''
+        """Verify scuba gracefully handles an image with no Cmd and no user command"""
 
-        with open('.scuba.yml', 'w') as f:
+        with open(".scuba.yml", "w") as f:
             f.write("image: scuba/scratch\n")
 
         # ScubaError -> exit(128)
         out, _ = self.run_scuba([], 128)
 
     def test_handle_get_image_command_error(self):
-        '''Verify scuba handles a get_image_command error'''
+        """Verify scuba handles a get_image_command error"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
         def mocked_gic(*args, **kw):
-            raise scuba.dockerutil.DockerError('mock error')
+            raise scuba.dockerutil.DockerError("mock error")
 
         # http://alexmarandon.com/articles/python_mock_gotchas/#patching-in-the-wrong-place
         # http://www.voidspace.org.uk/python/mock/patch.html#where-to-patch
-        with mock.patch('scuba.scuba.get_image_command', side_effect=mocked_gic):
+        with mock.patch("scuba.scuba.get_image_command", side_effect=mocked_gic):
             # DockerError -> exit(128)
             self.run_scuba([], 128)
 
-
     def test_config_error(self):
-        '''Verify config errors are handled gracefully'''
+        """Verify config errors are handled gracefully"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('invalid_key: is no good\n')
+        with open(".scuba.yml", "w") as f:
+            f.write("invalid_key: is no good\n")
 
         # ConfigError -> exit(128)
         self.run_scuba([], 128)
 
     def test_multiline_alias_no_args_error(self):
-        '''Verify config errors from passing arguments to multi-line alias are caught'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        """Verify config errors from passing arguments to multi-line alias are caught"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   multi:
@@ -149,137 +148,139 @@ class TestMain:
                       - echo multi
                       - echo line
                       - echo alias
-                ''')
+                """
+            )
 
         # ConfigError -> exit(128)
-        self.run_scuba(['multi', 'with', 'args'], 128)
-
-
+        self.run_scuba(["multi", "with", "args"], 128)
 
     def test_version(self):
-        '''Verify scuba prints its version for -v'''
+        """Verify scuba prints its version for -v"""
 
-        out, err = self.run_scuba(['-v'])
+        out, err = self.run_scuba(["-v"])
 
         name, ver = out.split()
-        assert name == 'scuba'
+        assert name == "scuba"
         assert ver == scuba.__version__
 
-
     def test_no_docker(self):
-        '''Verify scuba gracefully handles docker not being installed'''
+        """Verify scuba gracefully handles docker not being installed"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        args = ['/bin/echo', '-n', 'my output']
+        args = ["/bin/echo", "-n", "my output"]
 
-        old_PATH = os.environ['PATH']
-        os.environ['PATH'] = ''
+        old_PATH = os.environ["PATH"]
+        os.environ["PATH"] = ""
 
         try:
             _, err = self.run_scuba(args, 2)
         finally:
-            os.environ['PATH'] = old_PATH
+            os.environ["PATH"] = old_PATH
 
-    @mock.patch('subprocess.call')
+    @mock.patch("subprocess.call")
     def test_dry_run(self, subproc_call_mock):
-        '''Verify scuba handles --dry-run and --verbose'''
+        """Verify scuba handles --dry-run and --verbose"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        args = ['--dry-run', '--verbose', '/bin/false']
+        args = ["--dry-run", "--verbose", "/bin/false"]
 
         _, err = self.run_scuba(args)
 
         assert not subproc_call_mock.called
 
-        #TODO: Assert temp files are not cleaned up?
-
+        # TODO: Assert temp files are not cleaned up?
 
     def test_args(self):
-        '''Verify scuba handles cmdline args'''
+        """Verify scuba handles cmdline args"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        with open('test.sh', 'w') as f:
-            f.write('#!/bin/sh\n')
+        with open("test.sh", "w") as f:
+            f.write("#!/bin/sh\n")
             f.write('for a in "$@"; do echo $a; done\n')
-        make_executable('test.sh')
+        make_executable("test.sh")
 
-        lines = ['here', 'are', 'some args']
+        lines = ["here", "are", "some args"]
 
-        out, _ = self.run_scuba(['./test.sh'] + lines)
+        out, _ = self.run_scuba(["./test.sh"] + lines)
 
         assert_seq_equal(out.splitlines(), lines)
 
-
     def test_created_file_ownership(self):
-        '''Verify files created under scuba have correct ownership'''
+        """Verify files created under scuba have correct ownership"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        filename = 'newfile.txt'
+        filename = "newfile.txt"
 
-        self.run_scuba(['/bin/touch', filename])
+        self.run_scuba(["/bin/touch", filename])
 
         st = os.stat(filename)
         assert st.st_uid == os.getuid()
         assert st.st_gid == os.getgid()
 
-
     def _setup_test_tty(self):
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        with open('check_tty.sh', 'w') as f:
-            f.write('#!/bin/sh\n')
+        with open("check_tty.sh", "w") as f:
+            f.write("#!/bin/sh\n")
             f.write('if [ -t 1 ]; then echo "isatty"; else echo "notatty"; fi\n')
-        make_executable('check_tty.sh')
+        make_executable("check_tty.sh")
 
     @skipUnlessTty()
     def test_with_tty(self):
-        '''Verify docker allocates tty if stdout is a tty.'''
+        """Verify docker allocates tty if stdout is a tty."""
         self._setup_test_tty()
 
-        out, _ = self.run_scuba(['./check_tty.sh'], mock_isatty=True)
+        out, _ = self.run_scuba(["./check_tty.sh"], mock_isatty=True)
 
-        assert_str_equalish(out, 'isatty')
+        assert_str_equalish(out, "isatty")
 
     @skipUnlessTty()
     def test_without_tty(self):
-        '''Verify docker doesn't allocate tty if stdout is not a tty.'''
+        """Verify docker doesn't allocate tty if stdout is not a tty."""
         self._setup_test_tty()
 
-        out, _ = self.run_scuba(['./check_tty.sh'])
+        out, _ = self.run_scuba(["./check_tty.sh"])
 
-        assert_str_equalish(out, 'notatty')
+        assert_str_equalish(out, "notatty")
 
     def test_redirect_stdin(self):
-        '''Verify stdin redirection works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        """Verify stdin redirection works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        test_str = 'hello world'
-        with TemporaryFile(prefix='scubatest-stdin', mode='w+t') as stdin:
+        test_str = "hello world"
+        with TemporaryFile(prefix="scubatest-stdin", mode="w+t") as stdin:
             stdin.write(test_str)
             stdin.seek(0)
-            out, _ = self.run_scuba(['cat'], stdin=stdin)
+            out, _ = self.run_scuba(["cat"], stdin=stdin)
 
         assert_str_equalish(out, test_str)
 
+    def _test_user(
+        self,
+        expected_uid,
+        expected_username,
+        expected_gid,
+        expected_groupname,
+        scuba_args=[],
+    ):
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-    def _test_user(self,
-                   expected_uid, expected_username,
-                   expected_gid, expected_groupname,
-                   scuba_args=[]):
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
-
-        args = scuba_args + ['/bin/sh', '-c', 'echo $(id -u) $(id -un) $(id -g) $(id -gn)']
+        args = scuba_args + [
+            "/bin/sh",
+            "-c",
+            "echo $(id -u) $(id -un) $(id -g) $(id -gn)",
+        ]
         out, _ = self.run_scuba(args)
 
         uid, username, gid, groupname = out.split()
@@ -291,71 +292,74 @@ class TestMain:
         assert gid == expected_gid
         assert groupname == expected_groupname
 
-
     def test_user_scubauser(self):
-        '''Verify scuba runs container as the current (host) uid/gid'''
+        """Verify scuba runs container as the current (host) uid/gid"""
         self._test_user(
-            expected_uid = os.getuid(),
-            expected_username = getpwuid(os.getuid()).pw_name,
-            expected_gid = os.getgid(),
-            expected_groupname = getgrgid(os.getgid()).gr_name,
+            expected_uid=os.getuid(),
+            expected_username=getpwuid(os.getuid()).pw_name,
+            expected_gid=os.getgid(),
+            expected_groupname=getgrgid(os.getgid()).gr_name,
         )
 
     EXPECT_ROOT = dict(
-        expected_uid = 0,
-        expected_username = 'root',
-        expected_gid = 0,
-        expected_groupname = 'root',
+        expected_uid=0,
+        expected_username="root",
+        expected_gid=0,
+        expected_groupname="root",
     )
 
     def test_user_root(self):
-        '''Verify scuba -r runs container as root'''
+        """Verify scuba -r runs container as root"""
         self._test_user(
             **self.EXPECT_ROOT,
-            scuba_args = ['-r'],
+            scuba_args=["-r"],
         )
 
     def test_user_run_as_root(self):
         '''Verify running scuba as root is identical to "scuba -r"'''
 
-        with mock.patch('os.getuid', return_value=0) as getuid_mock, \
-             mock.patch('os.getgid', return_value=0) as getgid_mock:
-
+        with mock.patch("os.getuid", return_value=0) as getuid_mock, mock.patch(
+            "os.getgid", return_value=0
+        ) as getgid_mock:
             self._test_user(**self.EXPECT_ROOT)
             assert getuid_mock.called
             assert getgid_mock.called
 
     def test_user_root_alias(self):
-        '''Verify that aliases can set whether the container is run as root'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        """Verify that aliases can set whether the container is run as root"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   root_test:
                     root: true
                     script:
                       - echo $(id -u) $(id -un) $(id -g) $(id -gn)
-                ''')
+                """
+            )
 
         out, _ = self.run_scuba(["root_test"])
         uid, username, gid, groupname = out.split()
 
         assert int(uid) == 0
-        assert username == 'root'
+        assert username == "root"
         assert int(gid) == 0
-        assert groupname == 'root'
+        assert groupname == "root"
 
         # No one should ever specify 'root: false' in an alias, but Scuba should behave
         # correctly if they do
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   no_root_test:
                     root: false
                     script:
                       - echo $(id -u) $(id -un) $(id -g) $(id -gn)
-                ''')
+                """
+            )
 
         out, _ = self.run_scuba(["no_root_test"])
         uid, username, gid, groupname = out.split()
@@ -366,75 +370,81 @@ class TestMain:
         assert groupname == getgrgid(os.getgid()).gr_name
 
     def _test_home_writable(self, scuba_args=[]):
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        args = scuba_args + ['/bin/sh', '-c', 'echo success >> ~/testfile; cat ~/testfile']
+        args = scuba_args + [
+            "/bin/sh",
+            "-c",
+            "echo success >> ~/testfile; cat ~/testfile",
+        ]
         out, _ = self.run_scuba(args)
 
-        assert_str_equalish(out, 'success')
-
+        assert_str_equalish(out, "success")
 
     def test_home_writable_scubauser(self):
-        '''Verify scubauser has a writable homedir'''
+        """Verify scubauser has a writable homedir"""
 
         # Run this test in /home/$username if applicable
         username = getpwuid(os.getuid()).pw_name
-        homedir = os.path.expanduser('~')
+        homedir = os.path.expanduser("~")
 
-        expected = os.path.join('/home', username)
+        expected = os.path.join("/home", username)
         if homedir != expected:
-            warnings.warn(f"Homedir ({homedir}) is not as expected ({expected}); test inconclusive")
+            warnings.warn(
+                f"Homedir ({homedir}) is not as expected ({expected}); "
+                "test inconclusive"
+            )
 
-        with InTempDir(prefix='tmp-scubatest-', dir=homedir):
+        with InTempDir(prefix="tmp-scubatest-", dir=homedir):
             self._test_home_writable()
 
-
     def test_home_writable_root(self):
-        '''Verify root has a writable homedir'''
-        self._test_home_writable(['-r'])
-
+        """Verify root has a writable homedir"""
+        self._test_home_writable(["-r"])
 
     def test_arbitrary_docker_args(self):
-        '''Verify -d successfully passes arbitrary docker arguments'''
+        """Verify -d successfully passes arbitrary docker arguments"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        data = 'Lorem ipsum dolor sit amet'
-        data_path = '/lorem/ipsum'
+        data = "Lorem ipsum dolor sit amet"
+        data_path = "/lorem/ipsum"
 
-        with NamedTemporaryFile(mode='wt') as tempf:
+        with NamedTemporaryFile(mode="wt") as tempf:
             tempf.write(data)
             tempf.flush()
 
             args = [
-                f'-d=-v {tempf.name}:{data_path}:ro,z',
-                'cat', data_path,
+                f"-d=-v {tempf.name}:{data_path}:ro,z",
+                "cat",
+                data_path,
             ]
             out, _ = self.run_scuba(args)
 
         assert_str_equalish(out, data)
 
     def test_arbitrary_docker_args_merge_config(self):
-        '''Verify -d arguments are merged with docker_args in the config'''
-        dummy = Path('dummy')
+        """Verify -d arguments are merged with docker_args in the config"""
+        dummy = Path("dummy")
         dummy.touch()
         expfiles = set()
-        tgtdir = '/tgtdir'
+        tgtdir = "/tgtdir"
 
         def mount_dummy(name):
             assert name not in expfiles
             expfiles.add(name)
             return f'-v "{dummy.absolute()}:{tgtdir}/{name}"\n'
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
-            f.write('docker_args: ' + mount_dummy('one'))
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
+            f.write("docker_args: " + mount_dummy("one"))
 
         args = [
-            '-d=' + mount_dummy('two'),
-            'ls', tgtdir,
+            "-d=" + mount_dummy("two"),
+            "ls",
+            tgtdir,
         ]
         out, _ = self.run_scuba(args)
 
@@ -442,12 +452,12 @@ class TestMain:
         assert files == expfiles
 
     def test_nested_sript(self):
-        '''Verify nested scripts works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
-            f.write('aliases:\n')
-            f.write('  foo:\n')
-            f.write('    script:\n')
+        """Verify nested scripts works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
+            f.write("aliases:\n")
+            f.write("  foo:\n")
+            f.write("    script:\n")
             f.write('      - echo "This"\n')
             f.write('      - - echo "list"\n')
             f.write('        - echo "is"\n')
@@ -455,157 +465,165 @@ class TestMain:
             f.write('        - - echo "kinda"\n')
             f.write('          - echo "crazy"\n')
 
-        test_str = 'This list is nested kinda crazy'
-        out, _ = self.run_scuba(['foo'])
+        test_str = "This list is nested kinda crazy"
+        out, _ = self.run_scuba(["foo"])
 
-        out = out.replace('\n', ' ')
+        out = out.replace("\n", " ")
         assert_str_equalish(out, test_str)
-
 
     ############################################################################
     # Entrypoint
 
     def test_image_entrypoint(self):
-        '''Verify scuba doesn't interfere with the configured image ENTRYPOINT'''
+        """Verify scuba doesn't interfere with the configured image ENTRYPOINT"""
 
-        with open('.scuba.yml', 'w') as f:
-            f.write('image: scuba/entrypoint-test')
+        with open(".scuba.yml", "w") as f:
+            f.write("image: scuba/entrypoint-test")
 
-        out, _ = self.run_scuba(['cat', 'entrypoint_works.txt'])
-        assert_str_equalish('success', out)
-
+        out, _ = self.run_scuba(["cat", "entrypoint_works.txt"])
+        assert_str_equalish("success", out)
 
     def test_image_entrypoint_multiline(self):
-        '''Verify entrypoints are handled correctly with multi-line scripts'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """Verify entrypoints are handled correctly with multi-line scripts"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: scuba/entrypoint-test
                 aliases:
                   testalias:
                     script:
                       - cat entrypoint_works.txt
                       - echo $ENTRYPOINT_WORKS
-                ''')
+                """
+            )
 
-        out, _ = self.run_scuba(['testalias'])
-        assert_str_equalish('\n'.join(['success']*2), out)
-
+        out, _ = self.run_scuba(["testalias"])
+        assert_str_equalish("\n".join(["success"] * 2), out)
 
     def test_entrypoint_override(self):
-        '''Verify --entrypoint override works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """Verify --entrypoint override works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: scuba/entrypoint-test
                 aliases:
                   testalias:
                     script:
                       - echo $ENTRYPOINT_WORKS
-                ''')
+                """
+            )
 
-        test_str = 'This is output from the overridden entrypoint'
+        test_str = "This is output from the overridden entrypoint"
 
-        with open('new.sh', 'w') as f:
-            f.write('#!/bin/sh\n')
-            f.write(f'echo "{test_str}\"\n')
-        make_executable('new.sh')
+        with open("new.sh", "w") as f:
+            f.write("#!/bin/sh\n")
+            f.write(f'echo "{test_str}"\n')
+        make_executable("new.sh")
 
         args = [
-            '--entrypoint', os.path.abspath('new.sh'),
-            'true',
+            "--entrypoint",
+            os.path.abspath("new.sh"),
+            "true",
         ]
         out, _ = self.run_scuba(args)
         assert_str_equalish(test_str, out)
 
-
     def test_entrypoint_override_none(self):
-        '''Verify --entrypoint override (to nothing) works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """Verify --entrypoint override (to nothing) works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: scuba/entrypoint-test
                 aliases:
                   testalias:
                     script:
                       - echo $ENTRYPOINT_WORKS
-                ''')
+                """
+            )
 
         args = [
-            '--entrypoint', '',
-            'testalias',
+            "--entrypoint",
+            "",
+            "testalias",
         ]
         out, _ = self.run_scuba(args)
 
         # Verify that ENTRYPOINT_WORKS was not set by the entrypoint
         # (because it didn't run)
-        assert_str_equalish('', out)
-
+        assert_str_equalish("", out)
 
     def test_yaml_entrypoint_override(self):
-        '''Verify entrypoint in .scuba.yml works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """Verify entrypoint in .scuba.yml works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: scuba/entrypoint-test
                 entrypoint: "./new.sh"
-                ''')
+                """
+            )
 
-        test_str = 'This is output from the overridden entrypoint'
+        test_str = "This is output from the overridden entrypoint"
 
-        with open('new.sh', 'w') as f:
-            f.write('#!/bin/sh\n')
-            f.write(f'echo "{test_str}\"\n')
-        make_executable('new.sh')
+        with open("new.sh", "w") as f:
+            f.write("#!/bin/sh\n")
+            f.write(f'echo "{test_str}"\n')
+        make_executable("new.sh")
 
         args = [
-            'true',
+            "true",
         ]
         out, _ = self.run_scuba(args)
         assert_str_equalish(test_str, out)
 
-
     def test_yaml_entrypoint_override_none(self):
-        '''Verify "none" entrypoint in .scuba.yml works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write('''
+        """Verify "none" entrypoint in .scuba.yml works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                """
                 image: scuba/entrypoint-test
                 entrypoint:
                 aliases:
                   testalias:
                     script:
                       - echo $ENTRYPOINT_WORKS
-                ''')
+                """
+            )
 
         args = [
-            'testalias',
+            "testalias",
         ]
         out, _ = self.run_scuba(args)
 
         # Verify that ENTRYPOINT_WORKS was not set by the entrypoint
         # (because it didn't run)
-        assert_str_equalish('', out)
-
+        assert_str_equalish("", out)
 
     ############################################################################
     # Image override
 
     def test_image_override(self):
-        '''Verify --image works'''
+        """Verify --image works"""
 
-        with open('.scuba.yml', 'w') as f:
+        with open(".scuba.yml", "w") as f:
             # This image does not exist
-            f.write('image: scuba/notheredoesnotexistbb7e344f9722\n')
+            f.write("image: scuba/notheredoesnotexistbb7e344f9722\n")
 
         args = [
-            '--image', DOCKER_IMAGE,
-            'echo', 'success',
+            "--image",
+            DOCKER_IMAGE,
+            "echo",
+            "success",
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish('success', out)
+        assert_str_equalish("success", out)
 
     def test_image_override_with_alias(self):
-        '''Verify --image works with aliases'''
+        """Verify --image works with aliases"""
 
-        with open('.scuba.yml', 'w') as f:
+        with open(".scuba.yml", "w") as f:
             # These images do not exist
-            f.write('''
+            f.write(
+                """
                 image: scuba/notheredoesnotexistbb7e344f9722
                 aliases:
                   testalias:
@@ -614,120 +632,128 @@ class TestMain:
                       - echo multi
                       - echo line
                       - echo alias
-                ''')
+                """
+            )
 
         args = [
-            '--image', DOCKER_IMAGE,
-            'testalias',
+            "--image",
+            DOCKER_IMAGE,
+            "testalias",
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish('multi\nline\nalias', out)
+        assert_str_equalish("multi\nline\nalias", out)
 
     def test_yml_not_needed_with_image_override(self):
-        '''Verify .scuba.yml can be missing if --image is used'''
+        """Verify .scuba.yml can be missing if --image is used"""
 
         # no .scuba.yml
 
         args = [
-            '--image', DOCKER_IMAGE,
-            'echo', 'success',
+            "--image",
+            DOCKER_IMAGE,
+            "echo",
+            "success",
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish('success', out)
+        assert_str_equalish("success", out)
 
     def test_complex_commands_in_alias(self):
-        '''Verify complex commands can be used in alias scripts'''
-        test_string = 'Hello world'
-        os.mkdir('foo')
-        with open('foo/bar.txt', 'w') as f:
+        """Verify complex commands can be used in alias scripts"""
+        test_string = "Hello world"
+        os.mkdir("foo")
+        with open("foo/bar.txt", "w") as f:
             f.write(test_string)
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
-            f.write('aliases:\n')
-            f.write('  alias1:\n')
-            f.write('    script:\n')
-            f.write('      - cd foo && cat bar.txt\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
+            f.write("aliases:\n")
+            f.write("  alias1:\n")
+            f.write("    script:\n")
+            f.write("      - cd foo && cat bar.txt\n")
 
-        out, _ = self.run_scuba(['alias1'])
+        out, _ = self.run_scuba(["alias1"])
         assert_str_equalish(test_string, out)
-
 
     ############################################################################
     # Hooks
 
     def _test_one_hook(self, hookname, hookcmd, cmd, exp_retval=0):
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
-            f.write('hooks:\n')
-            f.write(f'  {hookname}: {hookcmd}\n')
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
+            f.write("hooks:\n")
+            f.write(f"  {hookname}: {hookcmd}\n")
 
-        args = ['/bin/sh', '-c', cmd]
+        args = ["/bin/sh", "-c", cmd]
         return self.run_scuba(args, exp_retval=exp_retval)
 
     def _test_hook_runs_as(self, hookname, exp_uid, exp_gid):
         out, _ = self._test_one_hook(
-                hookname,
-                'echo $(id -u) $(id -g)',
-                'echo success',
-                )
+            hookname,
+            "echo $(id -u) $(id -g)",
+            "echo success",
+        )
         out = out.splitlines()
 
         uid, gid = map(int, out[0].split())
         assert exp_uid == uid
         assert exp_gid == gid
 
-        assert_str_equalish(out[1], 'success')
+        assert_str_equalish(out[1], "success")
 
     def test_user_hook_runs_as_user(self):
-        '''Verify user hook executes as user'''
-        self._test_hook_runs_as('user', os.getuid(), os.getgid())
+        """Verify user hook executes as user"""
+        self._test_hook_runs_as("user", os.getuid(), os.getgid())
 
     def test_root_hook_runs_as_root(self):
-        '''Verify root hook executes as root'''
-        self._test_hook_runs_as('root', 0, 0)
+        """Verify root hook executes as root"""
+        self._test_hook_runs_as("root", 0, 0)
 
     def test_hook_failure_shows_correct_status(self):
         testval = 42
         out, err = self._test_one_hook(
-                'root',
-                f'exit {testval}',
-                'dont care',
-                exp_retval = SCUBAINIT_EXIT_FAIL,
-                )
-        assert re.match(f'^scubainit: .* exited with status {testval}$', err)
-
+            "root",
+            f"exit {testval}",
+            "dont care",
+            exp_retval=SCUBAINIT_EXIT_FAIL,
+        )
+        assert re.match(f"^scubainit: .* exited with status {testval}$", err)
 
     ############################################################################
     # Environment
 
     def test_env_var_keyval(self):
-        '''Verify -e KEY=VAL works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        """Verify -e KEY=VAL works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
         args = [
-            '-e', 'KEY=VAL',
-            '/bin/sh', '-c', 'echo $KEY',
+            "-e",
+            "KEY=VAL",
+            "/bin/sh",
+            "-c",
+            "echo $KEY",
         ]
         out, _ = self.run_scuba(args)
-        assert_str_equalish(out, 'VAL')
+        assert_str_equalish(out, "VAL")
 
     def test_env_var_key_only(self, monkeypatch):
-        '''Verify -e KEY works'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        """Verify -e KEY works"""
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
         args = [
-            '-e', 'KEY',
-            '/bin/sh', '-c', 'echo $KEY',
+            "-e",
+            "KEY",
+            "/bin/sh",
+            "-c",
+            "echo $KEY",
         ]
-        monkeypatch.setenv('KEY', 'mockedvalue')
+        monkeypatch.setenv("KEY", "mockedvalue")
         out, _ = self.run_scuba(args)
-        assert_str_equalish(out, 'mockedvalue')
-
+        assert_str_equalish(out, "mockedvalue")
 
     def test_env_var_sources(self, monkeypatch):
-        '''Verify scuba handles all possible environment variable sources'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(fr'''
+        """Verify scuba handles all possible environment variable sources"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                rf"""
                 image: {DOCKER_IMAGE}
                 environment:
                   FOO: Top-level
@@ -747,66 +773,71 @@ class TestMain:
                       FOO: Overridden
                       MORE: Hello world
                       EXTERNAL_3:
-                ''')
+                """
+            )
 
         args = [
-            '-e', 'EXTERNAL_1',
-            '-e', 'BAZ=From the command line',
-            'al',
+            "-e",
+            "EXTERNAL_1",
+            "-e",
+            "BAZ=From the command line",
+            "al",
         ]
 
-        monkeypatch.setenv('EXTERNAL_1', 'External value 1')
-        monkeypatch.setenv('EXTERNAL_2', 'External value 2')
-        monkeypatch.setenv('EXTERNAL_3', 'External value 3')
+        monkeypatch.setenv("EXTERNAL_1", "External value 1")
+        monkeypatch.setenv("EXTERNAL_2", "External value 2")
+        monkeypatch.setenv("EXTERNAL_3", "External value 3")
 
         out, _ = self.run_scuba(args)
 
         # Convert key/pair output to dictionary
-        result = dict( pair.split('=', 1) for pair in shlex.split(out) )
+        result = dict(pair.split("=", 1) for pair in shlex.split(out))
 
         assert result == dict(
-                FOO = "Overridden",
-                BAR = "42",
-                MORE = "Hello world",
-                EXTERNAL_1 = "External value 1",
-                EXTERNAL_2 = "External value 2",
-                EXTERNAL_3 = "External value 3",
-                BAZ = "From the command line",
-            )
+            FOO="Overridden",
+            BAR="42",
+            MORE="Hello world",
+            EXTERNAL_1="External value 1",
+            EXTERNAL_2="External value 2",
+            EXTERNAL_3="External value 3",
+            BAZ="From the command line",
+        )
 
     def test_builtin_env__SCUBA_ROOT(self, in_tmp_path):
-        '''Verify SCUBA_ROOT is set in container'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'image: {DOCKER_IMAGE}\n')
+        """Verify SCUBA_ROOT is set in container"""
+        with open(".scuba.yml", "w") as f:
+            f.write(f"image: {DOCKER_IMAGE}\n")
 
-        args = ['/bin/sh', '-c', 'echo $SCUBA_ROOT']
+        args = ["/bin/sh", "-c", "echo $SCUBA_ROOT"]
         out, _ = self.run_scuba(args)
 
         assert_str_equalish(in_tmp_path, out)
-
 
     ############################################################################
     # Shell Override
 
     def test_use_top_level_shell_override(self):
-        '''Verify that the shell can be overriden at the top level'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        """Verify that the shell can be overriden at the top level"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 shell: /bin/bash
                 aliases:
                   check_shell:
                     script: readlink -f /proc/$$/exe
-                ''')
+                """
+            )
 
-        out, _ = self.run_scuba(['check_shell'])
+        out, _ = self.run_scuba(["check_shell"])
         # If we failed to override, the shebang would be #!/bin/sh
         assert_str_equalish("/bin/bash", out)
 
     def test_alias_level_shell_override(self):
-        '''Verify that the shell can be overriden at the alias level without affecting other aliases'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        """Verify that the shell can be overriden at the alias level without affecting other aliases"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   shell_override:
@@ -814,86 +845,96 @@ class TestMain:
                     script: readlink -f /proc/$$/exe
                   default_shell:
                     script: readlink -f /proc/$$/exe
-                ''')
-        out, _ = self.run_scuba(['shell_override'])
+                """
+            )
+        out, _ = self.run_scuba(["shell_override"])
         assert_str_equalish("/bin/bash", out)
 
-        out, _ = self.run_scuba(['default_shell'])
+        out, _ = self.run_scuba(["default_shell"])
         # The way that we check the shell uses the resolved symlink of /bin/sh,
         # which is /bin/dash on Debian
         assert out.strip() in ["/bin/sh", "/bin/dash"]
 
     def test_cli_shell_override(self):
-        '''Verify that the shell can be overriden by the CLI'''
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        """Verify that the shell can be overriden by the CLI"""
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   default_shell:
                     script: readlink -f /proc/$$/exe
-                ''')
+                """
+            )
 
-        out, _ = self.run_scuba(['--shell', '/bin/bash', 'default_shell'])
+        out, _ = self.run_scuba(["--shell", "/bin/bash", "default_shell"])
         assert_str_equalish("/bin/bash", out)
 
     def test_shell_override_precedence(self):
-        '''Verify that shell overrides at different levels override each other as expected'''
+        """Verify that shell overrides at different levels override each other as expected"""
         # Precedence expectations are (with "<<" meaning "overridden by"):
         # Top-level SCUBA_YML shell << alias-level SCUBA_YML shell << CLI-specified shell
 
         # Test top-level << alias-level
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 shell: /bin/this_does_not_exist
                 aliases:
                   shell_override:
                     shell: /bin/bash
                     script: readlink -f /proc/$$/exe
-                ''')
-        out, _ = self.run_scuba(['shell_override'])
+                """
+            )
+        out, _ = self.run_scuba(["shell_override"])
         assert_str_equalish("/bin/bash", out)
 
         # Test alias-level << CLI
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 aliases:
                   shell_overridden:
                     shell: /bin/this_is_not_a_real_shell
                     script: readlink -f /proc/$$/exe
-                ''')
-        out, _ = self.run_scuba(['--shell', '/bin/bash', 'shell_overridden'])
+                """
+            )
+        out, _ = self.run_scuba(["--shell", "/bin/bash", "shell_overridden"])
         assert_str_equalish("/bin/bash", out)
 
         # Test top-level << CLI
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 shell: /bin/this_is_not_a_real_shell
                 aliases:
                   shell_check: readlink -f /proc/$$/exe
-                ''')
-        out, _ = self.run_scuba(['--shell', '/bin/bash', 'shell_check'])
+                """
+            )
+        out, _ = self.run_scuba(["--shell", "/bin/bash", "shell_check"])
         assert_str_equalish("/bin/bash", out)
 
     ############################################################################
     # Volumes
 
     def test_volumes_basic(self):
-        '''Verify volumes can be added at top-level and alias'''
+        """Verify volumes can be added at top-level and alias"""
 
         # Create some temporary directories with a file in each
-        topdata = Path('./topdata')
+        topdata = Path("./topdata")
         topdata.mkdir()
         (topdata / "thing").write_text("from the top\n")
 
-        aliasdata = Path('./aliasdata')
+        aliasdata = Path("./aliasdata")
         aliasdata.mkdir()
         (aliasdata / "thing").write_text("from the alias\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 volumes:
                   /topdata: {topdata.absolute()}
@@ -902,27 +943,28 @@ class TestMain:
                     volumes:
                       /aliasdata: {aliasdata.absolute()}
                     script: "cat /topdata/thing /aliasdata/thing"
-                ''')
+                """
+            )
 
-        out, _ = self.run_scuba(['doit'])
+        out, _ = self.run_scuba(["doit"])
         out = out.splitlines()
         assert out == ["from the top", "from the alias"]
 
-
     def test_volumes_alias_override(self):
-        '''Verify volumes can be overridden by an alias'''
+        """Verify volumes can be overridden by an alias"""
 
         # Create some temporary directories with a file in each
-        topdata = Path('./topdata')
+        topdata = Path("./topdata")
         topdata.mkdir()
         (topdata / "thing").write_text("from the top\n")
 
-        aliasdata = Path('./aliasdata')
+        aliasdata = Path("./aliasdata")
         aliasdata.mkdir()
         (aliasdata / "thing").write_text("from the alias\n")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 volumes:
                   /data: {topdata.absolute()}
@@ -931,32 +973,35 @@ class TestMain:
                     volumes:
                       /data: {aliasdata.absolute()}
                     script: "cat /data/thing"
-                ''')
+                """
+            )
 
         # Run a non-alias command
-        out, _ = self.run_scuba(['cat', '/data/thing'])
+        out, _ = self.run_scuba(["cat", "/data/thing"])
         out = out.splitlines()
         assert out == ["from the top"]
 
         # Run the alias
-        out, _ = self.run_scuba(['doit'])
+        out, _ = self.run_scuba(["doit"])
         out = out.splitlines()
         assert out == ["from the alias"]
 
     def test_volumes_host_path_create(self):
-        '''Missing host paths should be created before starting Docker'''
+        """Missing host paths should be created before starting Docker"""
 
-        userdir = Path('./user')
-        testfile = userdir / 'test.txt'
+        userdir = Path("./user")
+        testfile = userdir / "test.txt"
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 volumes:
                   /userdir: {userdir.absolute()}
-                ''')
+                """
+            )
 
-        self.run_scuba(['touch', '/userdir/test.txt'])
+        self.run_scuba(["touch", "/userdir/test.txt"])
 
         assert testfile.exists(), "Test file was not created"
 
@@ -965,16 +1010,17 @@ class TestMain:
         assert info.st_gid != 0, "Directory group is root"
 
     def test_volumes_host_path_permissions(self):
-        '''Host path permission errors should be ignored'''
+        """Host path permission errors should be ignored"""
 
-        rootdir = Path('./root')
-        userdir = rootdir / 'user'
-        testfile = userdir / 'test.txt'
+        rootdir = Path("./root")
+        userdir = rootdir / "user"
+        testfile = userdir / "test.txt"
 
         rootdir.mkdir()
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 volumes:
                   /userdir: {userdir.absolute()}
@@ -982,12 +1028,13 @@ class TestMain:
                    doit:
                       root: true
                       script: "touch /userdir/test.txt"
-                ''')
+                """
+            )
 
         try:
             # Prevent current user from creating directory
             rootdir.chmod(0o555)
-            self.run_scuba(['doit'])
+            self.run_scuba(["doit"])
         finally:
             # Restore permissions to allow deletion
             rootdir.chmod(0o755)
@@ -999,20 +1046,22 @@ class TestMain:
         assert info.st_gid == 0, "Directory group is root"
 
     def test_volumes_host_path_failure(self):
-        '''Host path failures due to OS errors prevent Docker run'''
+        """Host path failures due to OS errors prevent Docker run"""
 
-        rootdir = Path('./root')
-        userdir = rootdir / 'user'
-        testfile = userdir / 'test.txt'
+        rootdir = Path("./root")
+        userdir = rootdir / "user"
+        testfile = userdir / "test.txt"
 
         # rootdir is not a dir, it's a file
         rootdir.write_text("lied about the dir")
 
-        with open('.scuba.yml', 'w') as f:
-            f.write(f'''
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
                 image: {DOCKER_IMAGE}
                 volumes:
                   /userdir: {userdir.absolute()}
-                ''')
+                """
+            )
 
-        self.run_scuba(['touch', '/userdir/test.txt'], 128)
+        self.run_scuba(["touch", "/userdir/test.txt"], 128)

--- a/tests/test_scuba.py
+++ b/tests/test_scuba.py
@@ -4,357 +4,361 @@ import shlex
 from scuba.config import ScubaConfig, ConfigError, OverrideStr
 from scuba.scuba import ScubaContext
 
+
 class TestScubaContext:
     def test_process_command_image(self):
-        '''process_command returns the image and entrypoint'''
-        image_name = 'test_image'
-        entrypoint = 'test_entrypoint'
+        """process_command returns the image and entrypoint"""
+        image_name = "test_image"
+        entrypoint = "test_entrypoint"
 
         cfg = ScubaConfig(
-                image = image_name,
-                entrypoint = entrypoint,
-                )
+            image=image_name,
+            entrypoint=entrypoint,
+        )
         result = ScubaContext.process_command(cfg, [])
         assert result.image == image_name
         assert result.entrypoint == entrypoint
 
     def test_process_command_empty(self):
-        '''process_command handles no aliases and an empty command'''
+        """process_command handles no aliases and an empty command"""
         cfg = ScubaConfig(
-                image = 'na',
-                )
+            image="na",
+        )
         result = ScubaContext.process_command(cfg, [])
         assert result.script == None
 
-
     def test_process_command_no_aliases(self):
-        '''process_command handles no aliases'''
+        """process_command handles no aliases"""
         cfg = ScubaConfig(
-                image = 'na',
-                )
-        result = ScubaContext.process_command(cfg, ['cmd', 'arg1', 'arg2'])
+            image="na",
+        )
+        result = ScubaContext.process_command(cfg, ["cmd", "arg1", "arg2"])
         assert [shlex.split(s) for s in result.script] == [
-            ['cmd', 'arg1', 'arg2'],
+            ["cmd", "arg1", "arg2"],
         ]
 
     def test_process_command_aliases_unused(self):
-        '''process_command handles unused aliases'''
+        """process_command handles unused aliases"""
         cfg = ScubaConfig(
-                image = 'na',
-                aliases = dict(
-                    apple = 'banana',
-                    cat = 'dog',
-                    ),
-                )
-        result = ScubaContext.process_command(cfg, ['cmd', 'arg1', 'arg2'])
+            image="na",
+            aliases=dict(
+                apple="banana",
+                cat="dog",
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["cmd", "arg1", "arg2"])
         assert [shlex.split(s) for s in result.script] == [
-            ['cmd', 'arg1', 'arg2'],
+            ["cmd", "arg1", "arg2"],
         ]
 
     def test_process_command_aliases_used_noargs(self):
-        '''process_command handles aliases with no args'''
+        """process_command handles aliases with no args"""
         cfg = ScubaConfig(
-                image = 'na',
-                aliases = dict(
-                    apple = 'banana',
-                    cat = 'dog',
-                    ),
-                )
-        result = ScubaContext.process_command(cfg, ['apple', 'arg1', 'arg2'])
+            image="na",
+            aliases=dict(
+                apple="banana",
+                cat="dog",
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple", "arg1", "arg2"])
         assert [shlex.split(s) for s in result.script] == [
-            ['banana', 'arg1', 'arg2'],
+            ["banana", "arg1", "arg2"],
         ]
 
     def test_process_command_aliases_used_withargs(self):
-        '''process_command handles aliases with args'''
+        """process_command handles aliases with args"""
         cfg = ScubaConfig(
-                image = 'na',
-                aliases = dict(
-                    apple = 'banana cherry "pie is good"',
-                    cat = 'dog',
-                    ),
-                )
-        result = ScubaContext.process_command(cfg, ['apple', 'arg1', 'arg2 with spaces'])
+            image="na",
+            aliases=dict(
+                apple='banana cherry "pie is good"',
+                cat="dog",
+            ),
+        )
+        result = ScubaContext.process_command(
+            cfg, ["apple", "arg1", "arg2 with spaces"]
+        )
         assert [shlex.split(s) for s in result.script] == [
-            ['banana', 'cherry', 'pie is good', 'arg1', 'arg2 with spaces'],
+            ["banana", "cherry", "pie is good", "arg1", "arg2 with spaces"],
         ]
 
     def test_process_command_multiline_aliases_used(self):
-        '''process_command handles multiline aliases'''
+        """process_command handles multiline aliases"""
         cfg = ScubaConfig(
-                image = 'na',
-                aliases = dict(
-                    apple = dict(script=[
+            image="na",
+            aliases=dict(
+                apple=dict(
+                    script=[
                         'banana cherry "pie is good"',
-                        'so is peach',
-                    ]),
-                    cat = 'dog',
-                    ),
-                )
-        result = ScubaContext.process_command(cfg, ['apple'])
+                        "so is peach",
+                    ]
+                ),
+                cat="dog",
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
         assert [shlex.split(s) for s in result.script] == [
-            ['banana', 'cherry', 'pie is good'],
-            ['so', 'is', 'peach'],
+            ["banana", "cherry", "pie is good"],
+            ["so", "is", "peach"],
         ]
 
     def test_process_command_multiline_aliases_forbid_user_args(self):
-        '''process_command raises ConfigError when args are specified with multiline aliases'''
+        """process_command raises ConfigError when args are specified with multiline aliases"""
         cfg = ScubaConfig(
-                image = 'na',
-                aliases = dict(
-                    apple = dict(script=[
+            image="na",
+            aliases=dict(
+                apple=dict(
+                    script=[
                         'banana cherry "pie is good"',
-                        'so is peach',
-                    ]),
-                    cat = 'dog',
-                    ),
-                )
+                        "so is peach",
+                    ]
+                ),
+                cat="dog",
+            ),
+        )
         with pytest.raises(ConfigError):
-            ScubaContext.process_command(cfg, ['apple', 'ARGS', 'NOT ALLOWED'])
+            ScubaContext.process_command(cfg, ["apple", "ARGS", "NOT ALLOWED"])
 
     def test_process_command_alias_overrides_image(self):
-        '''aliases can override the image'''
+        """aliases can override the image"""
         cfg = ScubaConfig(
-                image = 'default',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                            'so is peach',
-                        ],
-                        image = 'overridden',
-                    ),
+            image="default",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                        "so is peach",
+                    ],
+                    image="overridden",
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.image == 'overridden'
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.image == "overridden"
 
     def test_process_command_alias_overrides_image_and_entrypoint(self):
-        '''aliases can override the image and entrypoint'''
+        """aliases can override the image and entrypoint"""
         cfg = ScubaConfig(
-                image = 'default',
-                entrypoint = 'default_entrypoint',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                            'so is peach',
-                        ],
-                        image = 'overridden',
-                        entrypoint = 'overridden_entrypoint',
-                    ),
+            image="default",
+            entrypoint="default_entrypoint",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                        "so is peach",
+                    ],
+                    image="overridden",
+                    entrypoint="overridden_entrypoint",
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.image == 'overridden'
-        assert result.entrypoint == 'overridden_entrypoint'
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.image == "overridden"
+        assert result.entrypoint == "overridden_entrypoint"
 
     def test_process_command_alias_overrides_image_and_empty_entrypoint(self):
-        '''aliases can override the image and empty/null entrypoint'''
+        """aliases can override the image and empty/null entrypoint"""
         cfg = ScubaConfig(
-                image = 'default',
-                entrypoint = 'default_entrypoint',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                            'so is peach',
-                        ],
-                        image = 'overridden',
-                        entrypoint = '',
-                    ),
+            image="default",
+            entrypoint="default_entrypoint",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                        "so is peach",
+                    ],
+                    image="overridden",
+                    entrypoint="",
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.image == 'overridden'
-        assert result.entrypoint == ''
-
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.image == "overridden"
+        assert result.entrypoint == ""
 
     def test_process_command_image_override(self):
-        '''process_command allows image to be overridden when provided'''
-        override_image_name = 'override_image'
+        """process_command allows image to be overridden when provided"""
+        override_image_name = "override_image"
 
         cfg = ScubaConfig(
-                image = 'test_image',
-                )
+            image="test_image",
+        )
         result = ScubaContext.process_command(cfg, [], image=override_image_name)
         assert result.image == override_image_name
 
     def test_process_command_image_override_missing(self):
-        '''process_command allows image to be overridden when not provided'''
-        override_image_name = 'override_image'
+        """process_command allows image to be overridden when not provided"""
+        override_image_name = "override_image"
 
         cfg = ScubaConfig()
         result = ScubaContext.process_command(cfg, [], image=override_image_name)
         assert result.image == override_image_name
 
     def test_process_command_image_override_alias(self):
-        '''process_command allows image to be overridden when provided by alias'''
-        override_image_name = 'override_image'
+        """process_command allows image to be overridden when provided by alias"""
+        override_image_name = "override_image"
 
         cfg = ScubaConfig(
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                            'so is peach',
-                        ],
-                        image = 'apple_image',
-                    ),
-                )
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                        "so is peach",
+                    ],
+                    image="apple_image",
+                ),
             )
+        )
         result = ScubaContext.process_command(cfg, [], image=override_image_name)
         assert result.image == override_image_name
 
     def test_env_merge(self):
-        '''process_command merges/overrides the environment from the alias'''
+        """process_command merges/overrides the environment from the alias"""
         cfg = ScubaConfig(
-                image = 'dontcare',
-                environment = dict(
-                    AAA = "aaa_base",
-                    BBB = "bbb_base",
-                ),
-                aliases = dict(
-                    test = dict(
-                        script = 'dontcare',
-                        environment = dict(
-                            BBB = "bbb_overridden",
-                            CCC = "ccc_overridden",
-                        ),
+            image="dontcare",
+            environment=dict(
+                AAA="aaa_base",
+                BBB="bbb_base",
+            ),
+            aliases=dict(
+                test=dict(
+                    script="dontcare",
+                    environment=dict(
+                        BBB="bbb_overridden",
+                        CCC="ccc_overridden",
                     ),
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['test'])
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["test"])
         expected = dict(
-            AAA = "aaa_base",
-            BBB = "bbb_overridden",
-            CCC = "ccc_overridden",
+            AAA="aaa_base",
+            BBB="bbb_overridden",
+            CCC="ccc_overridden",
         )
         assert result.environment == expected
 
     def test_process_command_alias_extends_docker_args(self):
-        '''aliases can extend the docker_args'''
+        """aliases can extend the docker_args"""
         cfg = ScubaConfig(
-                image = 'default',
-                docker_args = '--privileged',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                        docker_args = '-v /tmp/:/tmp/',
-                    ),
+            image="default",
+            docker_args="--privileged",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
+                    docker_args="-v /tmp/:/tmp/",
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.docker_args == ['--privileged', '-v', '/tmp/:/tmp/']
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.docker_args == ["--privileged", "-v", "/tmp/:/tmp/"]
 
     def test_process_command_alias_overrides_docker_args(self):
-        '''aliases can override the docker_args'''
+        """aliases can override the docker_args"""
         cfg = ScubaConfig(
-                image = 'default',
-                docker_args = '--privileged',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                        docker_args = OverrideStr('-v /tmp/:/tmp/'),
-                    ),
+            image="default",
+            docker_args="--privileged",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
+                    docker_args=OverrideStr("-v /tmp/:/tmp/"),
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.docker_args == ['-v', '/tmp/:/tmp/']
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.docker_args == ["-v", "/tmp/:/tmp/"]
 
     def test_process_command_alias_overrides_docker_args_with_empty(self):
-        '''aliases can override the docker_args'''
+        """aliases can override the docker_args"""
         cfg = ScubaConfig(
-                image = 'default',
-                docker_args = '--privileged',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                        docker_args = OverrideStr(''),
-                    ),
+            image="default",
+            docker_args="--privileged",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
+                    docker_args=OverrideStr(""),
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
         assert result.docker_args == []
 
     def test_process_command_alias_inherits_top_docker_args(self):
-        '''aliases inherit the top-level docker_args if not specified'''
+        """aliases inherit the top-level docker_args if not specified"""
         cfg = ScubaConfig(
-                image = 'default',
-                docker_args = '--privileged',
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                    ),
+            image="default",
+            docker_args="--privileged",
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
-        assert result.docker_args == ['--privileged']
-
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
+        assert result.docker_args == ["--privileged"]
 
     ############################################################################
     # volumes
 
     def test_process_command_alias_extends_volumes(self):
-        '''aliases can extend the volumes'''
+        """aliases can extend the volumes"""
         cfg = ScubaConfig(
-                image = 'default',
-                volumes = {
-                    '/foo': '/host/foo',
-                },
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                        volumes = {
-                            '/bar': '/host/bar',
-                        },
-                    ),
+            image="default",
+            volumes={
+                "/foo": "/host/foo",
+            },
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
+                    volumes={
+                        "/bar": "/host/bar",
+                    },
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
         vols = result.volumes
         assert len(vols) == 2
 
-        v = vols['/foo']
-        assert v.container_path == '/foo'
-        assert v.host_path == '/host/foo'
+        v = vols["/foo"]
+        assert v.container_path == "/foo"
+        assert v.host_path == "/host/foo"
 
-        v = vols['/bar']
-        assert v.container_path == '/bar'
-        assert v.host_path == '/host/bar'
+        v = vols["/bar"]
+        assert v.container_path == "/bar"
+        assert v.host_path == "/host/bar"
 
     def test_process_command_alias_updates_volumes(self):
-        '''aliases can extend the volumes'''
+        """aliases can extend the volumes"""
         cfg = ScubaConfig(
-                image = 'default',
-                volumes = {
-                    '/foo': '/host/foo',
-                },
-                aliases = dict(
-                    apple = dict(
-                        script = [
-                            'banana cherry "pie is good"',
-                        ],
-                        volumes = {
-                            '/foo': '/alternate/foo',
-                        },
-                    ),
+            image="default",
+            volumes={
+                "/foo": "/host/foo",
+            },
+            aliases=dict(
+                apple=dict(
+                    script=[
+                        'banana cherry "pie is good"',
+                    ],
+                    volumes={
+                        "/foo": "/alternate/foo",
+                    },
                 ),
-            )
-        result = ScubaContext.process_command(cfg, ['apple'])
+            ),
+        )
+        result = ScubaContext.process_command(cfg, ["apple"])
         vols = result.volumes
         assert len(vols) == 1
 
-        v = vols['/foo']
-        assert v.container_path == '/foo'
-        assert v.host_path == '/alternate/foo'
+        v = vols["/foo"]
+        assert v.container_path == "/foo"
+        assert v.host_path == "/alternate/foo"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,13 +11,13 @@ import scuba.utils
 
 def _parse_cmdline(cmdline):
     # Strip the formatting and whitespace
-    lines = [l.rstrip('\\').strip() for l in cmdline.splitlines()]
+    lines = [l.rstrip("\\").strip() for l in cmdline.splitlines()]
 
     # Split each line, and return a flattened list of arguments
     return chain.from_iterable(map(shlex.split, lines))
 
-def _test_format_cmdline(args):
 
+def _test_format_cmdline(args):
     # Call the unit-under-test to get the formatted command line
     result = scuba.utils.format_cmdline(args)
 
@@ -29,23 +29,32 @@ def _test_format_cmdline(args):
 
 
 def test_format_cmdline():
-    '''format_cmdline works as expected'''
+    """format_cmdline works as expected"""
 
-    _test_format_cmdline([
-        'something',
-        '-a',
-        '-b',
-        '--long', 'option text',
-        '-s', 'hort',
-        'a very long argument here that will end up on its own line because it is so wide and nothing else will fit at the default width',
-        'and now',
-        'some', 'more', 'stuff',
-        'and even more stuff',
-    ])
+    _test_format_cmdline(
+        [
+            "something",
+            "-a",
+            "-b",
+            "--long",
+            "option text",
+            "-s",
+            "hort",
+            (
+                "a very long argument here that will end up on its own line because it"
+                " is so wide and nothing else will fit at the default width"
+            ),
+            "and now",
+            "some",
+            "more",
+            "stuff",
+            "and even more stuff",
+        ]
+    )
 
 
 def test_shell_quote_cmd():
-    args = ['foo', 'bar pop', '"tee ball"']
+    args = ["foo", "bar pop", '"tee ball"']
 
     result = scuba.utils.shell_quote_cmd(args)
 
@@ -55,35 +64,41 @@ def test_shell_quote_cmd():
 
 
 def test_parse_env_var():
-    '''parse_env_var returns a key, value pair'''
-    result = scuba.utils.parse_env_var('KEY=value')
-    assert result == ('KEY', 'value')
+    """parse_env_var returns a key, value pair"""
+    result = scuba.utils.parse_env_var("KEY=value")
+    assert result == ("KEY", "value")
+
 
 def test_parse_env_var_more_equals():
-    '''parse_env_var handles multiple equals signs'''
-    result = scuba.utils.parse_env_var('KEY=anotherkey=value')
-    assert result == ('KEY', 'anotherkey=value')
+    """parse_env_var handles multiple equals signs"""
+    result = scuba.utils.parse_env_var("KEY=anotherkey=value")
+    assert result == ("KEY", "anotherkey=value")
+
 
 def test_parse_env_var_no_equals(monkeypatch):
-    '''parse_env_var handles no equals and gets value from environment'''
-    monkeypatch.setenv('KEY', 'mockedvalue')
-    result = scuba.utils.parse_env_var('KEY')
-    assert result == ('KEY', 'mockedvalue')
+    """parse_env_var handles no equals and gets value from environment"""
+    monkeypatch.setenv("KEY", "mockedvalue")
+    result = scuba.utils.parse_env_var("KEY")
+    assert result == ("KEY", "mockedvalue")
+
 
 def test_parse_env_var_not_set(monkeypatch):
-    '''parse_env_var returns an empty string if not set'''
-    monkeypatch.delenv('NOTSET', raising=False)
-    result = scuba.utils.parse_env_var('NOTSET')
-    assert result == ('NOTSET', '')
+    """parse_env_var returns an empty string if not set"""
+    monkeypatch.delenv("NOTSET", raising=False)
+    result = scuba.utils.parse_env_var("NOTSET")
+    assert result == ("NOTSET", "")
+
 
 def test_flatten_list__not_list():
     with pytest.raises(ValueError):
-        scuba.utils.flatten_list('abc')
+        scuba.utils.flatten_list("abc")
+
 
 def test_flatten_list__not_nested():
     sample = [1, 2, 3, 4]
     result = scuba.utils.flatten_list(sample)
     assert result == sample
+
 
 def test_flatten_list__nested_1():
     sample = [
@@ -92,24 +107,27 @@ def test_flatten_list__nested_1():
         4,
         [5, 6, 7],
     ]
-    exp = range(1, 7+1)
+    exp = range(1, 7 + 1)
     result = scuba.utils.flatten_list(sample)
     assert_seq_equal(result, exp)
+
 
 def test_flatten_list__nested_many():
     sample = [
         1,
         [2, 3],
         [4, 5, [6, 7, 8]],
-        9, 10,
+        9,
+        10,
         [11, [12, [13, [14, [15, [16, 17, 18]]]]]],
     ]
-    exp = range(1, 18+1)
+    exp = range(1, 18 + 1)
     result = scuba.utils.flatten_list(sample)
     assert_seq_equal(result, exp)
 
+
 def test_get_umask():
-    testval = 0o123     # unlikely default
+    testval = 0o123  # unlikely default
     orig = os.umask(testval)
     try:
         # Ensure our test is valid
@@ -123,18 +141,24 @@ def test_get_umask():
     finally:
         os.umask(orig)
 
+
 def test_writeln():
     with io.StringIO() as s:
-        scuba.utils.writeln(s, 'hello')
-        scuba.utils.writeln(s, 'goodbye')
-        assert s.getvalue() == 'hello\ngoodbye\n'
+        scuba.utils.writeln(s, "hello")
+        scuba.utils.writeln(s, "goodbye")
+        assert s.getvalue() == "hello\ngoodbye\n"
+
 
 def test_expand_env_vars(monkeypatch):
     monkeypatch.setenv("MY_VAR", "my favorite variable")
-    assert scuba.utils.expand_env_vars("This is $MY_VAR") == \
-            "This is my favorite variable"
-    assert scuba.utils.expand_env_vars("What is ${MY_VAR}?") == \
-            "What is my favorite variable?"
+    assert (
+        scuba.utils.expand_env_vars("This is $MY_VAR") == "This is my favorite variable"
+    )
+    assert (
+        scuba.utils.expand_env_vars("What is ${MY_VAR}?")
+        == "What is my favorite variable?"
+    )
+
 
 def test_expand_missing_env_vars(monkeypatch):
     monkeypatch.delenv("MY_VAR", raising=False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,47 +11,55 @@ from unittest import mock
 def assert_seq_equal(a, b):
     assert list(a) == list(b)
 
+
 def assert_paths_equal(a, b):
     # TODO: normpath() updatd to handle Path in Python 3.6
     a = str(a)
     b = str(b)
     assert normpath(a) == normpath(b)
 
+
 def assert_str_equalish(exp, act):
     exp = str(exp).strip()
     act = str(act).strip()
     assert exp == act
 
+
 def make_executable(path):
     mode = os.stat(path).st_mode
-    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    mode |= (mode & 0o444) >> 2  # copy R bits to X
     os.chmod(path, mode)
+
 
 def mock_open():
     real_open = open
+
     def mocked_open(*args, **kwargs):
         return real_open(*args, **kwargs)
 
-    return mock.patch('builtins.open', side_effect=mocked_open)
+    return mock.patch("builtins.open", side_effect=mocked_open)
 
 
 # http://stackoverflow.com/a/8389373/119527
 class PseudoTTY:
     def __init__(self, underlying):
         self.__underlying = underlying
+
     def __getattr__(self, name):
         return getattr(self.__underlying, name)
+
     def isatty(self):
         return True
 
 
 def skipUnlessTty():
-    return unittest.skipUnless(sys.stdin.isatty(),
-            "Can't test docker tty if not connected to a terminal")
+    return unittest.skipUnless(
+        sys.stdin.isatty(), "Can't test docker tty if not connected to a terminal"
+    )
 
 
 class InTempDir:
-    def __init__(self, suffix='', prefix='tmp', dir=None, delete=True):
+    def __init__(self, suffix="", prefix="tmp", dir=None, delete=True):
         self.delete = delete
         self.temp_path = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
 


### PR DESCRIPTION
- The codebase is formatted with [Black](https://black.readthedocs.io/).
- A `code_format.py` script makes checking/fixing code formatting locally easy.
- A GitHub action enforces proper formatting for all PRs.