### PR TITLE
Add pyproject.toml and move metadata from setup.py

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,15 +15,18 @@ jobs:
       fail-fast: False
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v3
 
     # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
-    - run: git fetch --prune --unshallow
+    - name: Unshallow checkout
+      run: git fetch --prune --unshallow
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -34,10 +37,13 @@ jobs:
         sudo apt-get install -y musl-tools
 
         ci/test_setup.sh
-        pip install wheel
-    - name: Run tests
+
+    - name: Build
       run: |
         python -m build
+
+    - name: Run tests
+      run: |
         pip install dist/scuba-*-py3-none-any.whl
         ./run_unit_tests.sh
         ./run_full_tests.py

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
         pip install wheel
     - name: Run tests
       run: |
-        python setup.py bdist_wheel
+        python -m build
         pip install dist/scuba-*-py3-none-any.whl
         ./run_unit_tests.sh
         ./run_full_tests.py

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,6 +44,8 @@ jobs:
 
     - name: Run tests
       run: |
+        # Make sure we only use the wheel
+        rm -r scuba scubainit
         pip install dist/scuba-*-py3-none-any.whl
         ./run_unit_tests.sh
         ./run_full_tests.py

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install twine
         sudo apt-get update
         sudo apt-get install -y musl-tools
 
@@ -35,5 +35,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_TEST_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install twine
         sudo apt-get update
         sudo apt-get install -y musl-tools
 
@@ -30,5 +30,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Introduced `pyproject.toml` and moved metadata from `setup.py` (#211)
+
 ### Removed
 - Drop support for Python 3.5 - 3.6
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "scuba"
+dynamic = ["version"]
+
+authors = [
+    {name = "Jonathon Reinhart", email="jonathon.reinhart@gmail.com"},
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Topic :: Software Development :: Build Tools",
+]
+dependencies = [
+    "PyYAML",
+]
+description = "Simplify use of Docker containers for building software"
+keywords = ["docker"]
+license = {file = "LICENSE.txt"}
+readme = "README.md"
+requires-python = ">=3.7"
+
+[project.optional-dependencies]
+argcomplete = ["argcomplete>=1.10.1"]
+
+[project.scripts]
+scuba = "scuba.__main__:main"
+
+[project.urls]
+documentation = "https://scuba.readthedocs.io/"
+repository = "https://github.com/JonathonReinhart/scuba"
+changelog = "https://github.com/JonathonReinhart/scuba/blob/main/CHANGELOG.md"
+
+
+[build-system]
+# Tells pip to install wheel before trying to install
+# from an sdist or from Github.
+requires = [
+    "wheel",
+    "setuptools >= 42.0.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argcomplete >= 1.10.1
+build
 PyYAML
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from setuptools.command.sdist import sdist
 from subprocess import check_call
 import os
 
+################################################################################
+# Build Hooks
+
 
 class build_scubainit(Command):
     description = "Build scubainit binary"
@@ -27,13 +30,6 @@ class build_hook(build):
         build.run(self)
 
 
-def read_project_file(path):
-    proj_dir = os.path.dirname(__file__)
-    path = os.path.join(proj_dir, path)
-    with open(path, "r") as f:
-        return f.read()
-
-
 ################################################################################
 # Dynamic versioning
 
@@ -52,27 +48,15 @@ def get_version():
 ################################################################################
 
 setup(
-    name="scuba",
+    #####
+    # Dynamic core metadata, in addition to pyproject.toml [project]
     version=get_version(),
-    python_requires=">=3.7",
-    description="Simplify use of Docker containers for building software",
-    long_description=read_project_file("README.md"),
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Natural Language :: English",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: MacOS :: MacOS X",
-        "Topic :: Software Development :: Build Tools",
-    ],
-    license="MIT",
-    keywords="docker",
-    author="Jonathon Reinhart",
-    author_email="jonathon.reinhart@gmail.com",
-    url="https://github.com/JonathonReinhart/scuba",
+    #####
+    # Setuptools-specific config
+    # We could put this in pyproject.toml [tool.setuptools], but choose not to:
+    # - The functionality is still in beta and requires setuptools >= 61.0.0
+    # - We need setup.py to provide build_hook, so we might as well keep all
+    #   setuptools-specific config here, in one file.
     packages=["scuba"],
     package_data={
         "scuba": [
@@ -81,19 +65,6 @@ setup(
     },
     include_package_data=True,  # https://github.com/pypa/setuptools/issues/1064
     zip_safe=False,  # http://stackoverflow.com/q/24642788/119527
-    entry_points={
-        "console_scripts": [
-            "scuba = scuba.__main__:main",
-        ]
-    },
-    install_requires=[
-        "PyYAML",
-    ],
-    extras_require={
-        "argcomplete": [
-            "argcomplete>=1.10.1",
-        ],
-    },
     # http://stackoverflow.com/questions/17806485
     # http://stackoverflow.com/questions/21915469
     cmdclass={


### PR DESCRIPTION
This is a step toward modernizing the project packaging, and allows us to begin defining tooling config in `pyproject.toml`.

References:
- https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

Tested:
- `python3 -m build`
- diff generated `scuba-*.dist-info/*` files and ensure only minimal, expected changes

Closes #203