### PR TITLE
Remove black --target-version

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          # TODO(#203): Remove target-version when we add pyproject.toml
-          options: "--check --color --diff --target-version=py37"
+          options: "--check --color --diff"
           src: "."
           version: "~= 23.0"  # Must match requirements.txt

--- a/code_format.py
+++ b/code_format.py
@@ -5,8 +5,6 @@ import black
 
 def _run_black(fix: bool) -> bool:
     args = [
-        # TODO(#203): Remove target-version when we add pyproject.toml
-        "--target-version=py37",
         ".",
     ]
 


### PR DESCRIPTION
Now that we use pyproject.toml, black can know this without being told.