### PR TITLE
docs: Correct docs regarding the use of env vars in volumes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -166,22 +166,27 @@ of volume options:
         hostpath: /host/foo
         options: ro,cached
 
-The keys used in volume mappings can contain environment variables **that are
-expanded in the host environment**. For example, this configuration would map
-the user's ``/home/username/.config/application1`` directory into the container
-at the same path.
+The paths (host or container) used in volume mappings can contain environment
+variables **which are expanded in the host environment**. For example, this
+configuration would map the user's ``/home/username/.config/application1``
+directory into the container at the same path.
 
 .. code-block:: yaml
 
     volumes:
       $TEST_HOME/.config/application1: $TEST_HOME/.config/application1
 
-Note that because variable expansion is now applied to all volume keys, if one
-desires to have a key with an explicit ``$`` character, it must be written as
-``$$``.
+If a referenced environment variable is not set, Scuba exits with a
+configuration error.
 
 Volume host directories which do not already exist are created as the current
 user before creating the container.
+
+.. note::
+   Because variable expansion is now applied to all volume paths, if one
+   desires to use a literal ``$`` character in a path, it must be written as
+   ``$$``.
+
 
 .. _conf_aliases:
 


### PR DESCRIPTION
Environment variables can be used in either the key (the container path) *or* in the host path, as shown in the accompanying example.

See also this test:
https://github.com/JonathonReinhart/scuba/blob/c6f3e62570/tests/test_config.py#L986

Also, move the existing note to a `note::` admonition, and indicate that unset variables will cause a config error.