### PR TITLE
Fix make_vol_opt trailing colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added type annotations to scuba package and mypy checking in CI (#207)
 
 ### Removed
-- Drop support for Python 3.5 - 3.6
+- Drop support for Python 3.5 - 3.6 (#205)
+
+### Fixed
+- Fixed bug causing invalid volume spec error on Docker 24.0.5 and newer (#217)
+
 
 ## [2.10.1] - 2023-03-07
 ### Fixed

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -137,8 +137,7 @@ def make_vol_opt(
 ) -> str:
     """Generate a docker volume option"""
     vol = f"--volume={hostdir}:{contdir}"
-    if options is not None:
-        if isinstance(options, str):
-            options = (options,)
+    if options:
+        assert not isinstance(options, str)
         vol += ":" + ",".join(options)
     return vol

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -108,11 +108,8 @@ def test_make_vol_opt_no_opts():
     assert uut.make_vol_opt("/hostdir", "/contdir") == "--volume=/hostdir:/contdir"
 
 
-def test_make_vol_opt_one_opt():
-    assert (
-        uut.make_vol_opt("/hostdir", "/contdir", "ro")
-        == "--volume=/hostdir:/contdir:ro"
-    )
+def test_make_vol_opt_empty_opts():
+    assert uut.make_vol_opt("/hostdir", "/contdir", []) == "--volume=/hostdir:/contdir"
 
 
 def test_make_vol_opt_multi_opts():


### PR DESCRIPTION
This fixes a bug in `scuba.dockerutil.make_vol_opt()` whereby passing `options=[]` (which is what will typically happen if a volume is specified in `.scuba.yml` without including `options:`) will cause a docker CLI volume spec to erroneously include a trailing colon, which is fatal as of Docker CLI 24.0.5.

Fixes #215