### PR TITLE
Ensure files added to test-docker-images are executable by all

### DIFF
--- a/test-docker-images/entrypoint-test/Dockerfile
+++ b/test-docker-images/entrypoint-test/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:latest
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test-docker-images/hello/Dockerfile
+++ b/test-docker-images/hello/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine
 ADD hello.sh /hello.sh
+RUN chmod 755 /hello.sh
 CMD ["/hello.sh"]


### PR DESCRIPTION
This resolves the issue where the files exist as e.g. 750 when building the image (due to paranoid umask 0027).

Fixes #220