### PR TITLE
Use path objects throughout

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -132,14 +132,14 @@ def run_scuba(scuba_args: argparse.Namespace) -> int:
         # .scuba.yml is allowed to be missing if --image was given.
         if not scuba_args.image:
             raise
-        top_path, top_rel, config = os.getcwd(), "", ScubaConfig()
+        top_path, top_rel, config = Path.cwd(), Path(), ScubaConfig()
 
     # Set up scuba Docker invocation
     dive = ScubaDive(
         user_command=scuba_args.command,
         config=config,
-        top_path=Path(top_path),  # TODO: remove Path()
-        top_rel=Path(top_rel),  # TODO: remove Path()
+        top_path=top_path,
+        top_rel=top_rel,
         docker_args=scuba_args.docker_args,
         env=scuba_args.env_vars,
         as_root=scuba_args.root,

--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -8,6 +8,7 @@ import sys
 import shlex
 import itertools
 import argparse
+from pathlib import Path
 from typing import Any, Optional, Sequence
 
 try:
@@ -137,8 +138,8 @@ def run_scuba(scuba_args: argparse.Namespace) -> int:
     dive = ScubaDive(
         user_command=scuba_args.command,
         config=config,
-        top_path=top_path,
-        top_rel=top_rel,
+        top_path=Path(top_path),  # TODO: remove Path()
+        top_rel=Path(top_rel),  # TODO: remove Path()
         docker_args=scuba_args.docker_args,
         env=scuba_args.env_vars,
         as_root=scuba_args.root,

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -109,9 +109,7 @@ class Loader(yaml.SafeLoader):
         # Load the other YAML document
         doc = self._cache.get(path)
         if not doc:
-            # TODO: Use path.open(), paired with open() in load_config() for convenience in
-            # tests/test_config.py::TestConfig::test_load_config_from_yaml_cached_file.
-            with open(str(path), "r") as f:
+            with path.open("r") as f:
                 doc = yaml.load(f, self.__class__)
                 self._cache[path] = doc
 
@@ -176,7 +174,7 @@ def find_config() -> Tuple[str, str, ScubaConfig]:
     while True:
         cfg_path = os.path.join(path, SCUBA_YML)
         if os.path.exists(cfg_path):
-            return path, rel, load_config(cfg_path)
+            return path, rel, load_config(Path(cfg_path))  # TODO: remove Path()
 
         if not cross_fs and os.path.ismount(path):
             raise ConfigNotFoundError(
@@ -500,9 +498,9 @@ class ScubaConfig:
         return self._image
 
 
-def load_config(path: str) -> ScubaConfig:
+def load_config(path: Path) -> ScubaConfig:
     try:
-        with open(path, "r") as f:
+        with path.open("r") as f:
             data = yaml.load(f, Loader)
     except IOError as e:
         raise ConfigError(f"Error opening {SCUBA_YML}: {e}")

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import dataclasses
 import os
+from pathlib import Path
 import re
 import shlex
 from typing import Any, List, Dict, Optional, TextIO, Tuple, Type, TypeVar, Union
@@ -393,7 +394,10 @@ class ScubaVolume:
         raise ConfigError(f"{cpath}: must be string or dict")
 
     def get_vol_opt(self) -> str:
-        return make_vol_opt(self.host_path, self.container_path, self.options)
+        # TODO: change host_path and container_path to Path objects
+        return make_vol_opt(
+            Path(self.host_path), Path(self.container_path), self.options
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import subprocess
 import json
 from typing import Any, Dict, IO, Optional, Sequence, Union
+from pathlib import Path
 
 # https://github.com/python/typeshed/blob/main/stdlib/subprocess.pyi
 _CMD = Union[str, bytes, Sequence[Union[str, bytes]]]
@@ -131,8 +132,8 @@ def get_image_entrypoint(image: str) -> Optional[Sequence[str]]:
 
 
 def make_vol_opt(
-    hostdir: str,
-    contdir: str,
+    hostdir: Path,
+    contdir: Path,
     options: Optional[Sequence[str]] = None,
 ) -> str:
     """Generate a docker volume option"""

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -191,7 +191,7 @@ class ScubaDive:
             return
 
         for vol in self.context.volumes.values():
-            if os.path.exists(vol.host_path):
+            if vol.host_path.exists():
                 continue
 
             try:
@@ -403,7 +403,7 @@ class ScubaDive:
 class ScubaContext:
     image: str
     environment: Dict[str, str]  # key: value
-    volumes: Dict[str, ScubaVolume]
+    volumes: Dict[Path, ScubaVolume]
     shell: str
     docker_args: List[str]
     script: Optional[List[str]] = None  # TODO: drop Optional?
@@ -435,7 +435,7 @@ class ScubaContext:
         entrypoint = cfg.entrypoint
         environment = copy.copy(cfg.environment)
         docker_args = copy.copy(cfg.docker_args) or []
-        volumes: Dict[str, ScubaVolume] = copy.copy(cfg.volumes or {})
+        volumes: Dict[Path, ScubaVolume] = copy.copy(cfg.volumes or {})
         as_root = False
 
         if command:

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 from grp import getgrgid
 from io import StringIO
+from pathlib import Path
 from pwd import getpwuid
 from typing import cast, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 from typing import TextIO
@@ -369,7 +370,8 @@ class ScubaDive:
             args.append(f"--env={name}={val}")
 
         for hostpath, contpath, options in self.__get_vol_opts():
-            args.append(make_vol_opt(hostpath, contpath, options))
+            # TODO: update __get_vol_opts() to return Path objects or ScubaVolume objects
+            args.append(make_vol_opt(Path(hostpath), Path(contpath), options))
 
         for _, vol in self.context.volumes.items():
             args.append(vol.get_vol_opt())

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -19,7 +19,7 @@ from .dockerutil import get_image_entrypoint
 from .dockerutil import make_vol_opt
 from .utils import shell_quote_cmd, flatten_list, get_umask, writeln
 
-VolumeTuple = Tuple[str, str, List[str]]
+VolumeTuple = Tuple[Path, Path, List[str]]
 
 
 class ScubaError(Exception):
@@ -39,8 +39,8 @@ class ScubaDive:
         self,
         user_command: List[str],
         config: ScubaConfig,
-        top_path: str,
-        top_rel: str,
+        top_path: Path,
+        top_rel: Path,
         docker_args: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = None,
         as_root: bool = False,
@@ -60,7 +60,7 @@ class ScubaDive:
         self.volumes = []
         self.options = []
         self.docker_args = docker_args or []
-        self.workdir: Optional[str] = None
+        self.workdir: Optional[Path] = None
 
         self.__scubadir_hostpath: Optional[str] = None
         self.__scubadir_contpath: Optional[str] = None
@@ -70,9 +70,9 @@ class ScubaDive:
         self.add_volume(top_path, top_path)
 
         # ...and set the working dir relative to it
-        self.set_workdir(os.path.join(top_path, top_rel))
+        self.set_workdir(top_path / top_rel)
 
-        self.add_env("SCUBA_ROOT", top_path)
+        self.add_env("SCUBA_ROOT", str(top_path))
 
         try:
             # Process any aliases
@@ -130,7 +130,7 @@ class ScubaDive:
             for val in vals or ():
                 writeln(s, f"{indent * (level + 1)}{val}")
 
-        def writescl(name: str, val: Union[None, bool, float, str]) -> None:
+        def writescl(name: str, val: Union[None, bool, float, str, Path]) -> None:
             writeln(s, f"{indent * level}{name + ':':<14s}{val}")
 
         writeln(s, "ScubaDive")
@@ -168,11 +168,13 @@ class ScubaDive:
 
     def add_volume(
         self,
-        hostpath: str,
-        contpath: str,
+        hostpath: Union[Path, str],
+        contpath: Union[Path, str],
         options: Optional[List[str]] = None,
     ) -> None:
         """Add a volume (bind-mount) to the docker run invocation"""
+        hostpath = Path(hostpath)
+        contpath = Path(contpath)
         if options is None:
             options = []
         self.volumes.append((hostpath, contpath, options))
@@ -205,7 +207,7 @@ class ScubaDive:
         """Add another option to the docker run invocation"""
         self.options.append(option)
 
-    def set_workdir(self, workdir: str) -> None:
+    def set_workdir(self, workdir: Path) -> None:
         self.workdir = workdir
 
     def __locate_scubainit(self) -> str:
@@ -370,14 +372,13 @@ class ScubaDive:
             args.append(f"--env={name}={val}")
 
         for hostpath, contpath, options in self.__get_vol_opts():
-            # TODO: update __get_vol_opts() to return Path objects or ScubaVolume objects
-            args.append(make_vol_opt(Path(hostpath), Path(contpath), options))
+            args.append(make_vol_opt(hostpath, contpath, options))
 
         for _, vol in self.context.volumes.items():
             args.append(vol.get_vol_opt())
 
         if self.workdir:
-            args += ["-w", self.workdir]
+            args += ["-w", str(self.workdir)]
 
         args += self.options
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,13 +5,14 @@ import pytest
 import logging
 import os
 from os.path import join
+from pathlib import Path
 from shutil import rmtree
 
 import scuba.config
 
 
 def load_config() -> scuba.config.ScubaConfig:
-    return scuba.config.load_config(".scuba.yml")
+    return scuba.config.load_config(Path(".scuba.yml"))
 
 
 class TestCommonScriptSchema:
@@ -216,13 +217,13 @@ class TestConfig:
             f.write("    image:  !from_yaml .gitlab.yml three\n")
             f.write("    script: ugh\n")
 
-        with mock_open() as m:
+        with mock.patch.object(Path, "open", autospec=True, side_effect=Path.open) as m:
             config = load_config()
 
         # Assert that .gitlab.yml was only opened once
         assert m.mock_calls == [
-            mock.call(".scuba.yml", "r"),
-            mock.call(".gitlab.yml", "r"),
+            mock.call(Path(".scuba.yml"), "r"),
+            mock.call(Path(".gitlab.yml"), "r"),
         ]
 
     def test_load_config_image_from_yaml_nested_key_missing(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,10 @@ from shutil import rmtree
 import scuba.config
 
 
+def load_config() -> scuba.config.ScubaConfig:
+    return scuba.config.load_config(".scuba.yml")
+
+
 class TestCommonScriptSchema:
     def test_simple(self) -> None:
         """Simple form: value is a string"""
@@ -106,14 +110,14 @@ class TestConfig:
 
     def _invalid_config(self, match=None):
         with pytest.raises(scuba.config.ConfigError, match=match) as e:
-            scuba.config.load_config(".scuba.yml")
+            load_config()
 
     def test_load_config_no_image(self) -> None:
         """load_config raises ConfigError if the config is empty and image is referenced"""
         with open(".scuba.yml", "w") as f:
             pass
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         with pytest.raises(scuba.config.ConfigError):
             img = config.image
 
@@ -130,7 +134,7 @@ class TestConfig:
         with open(".scuba.yml", "w") as f:
             f.write("image: bosybux\n")
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "bosybux"
 
     def test_load_config_with_aliases(self) -> None:
@@ -141,7 +145,7 @@ class TestConfig:
             f.write("  foo: bar\n")
             f.write("  snap: crackle pop\n")
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "bosybux"
         assert len(config.aliases) == 2
         assert config.aliases["foo"].script == ["bar"]
@@ -164,7 +168,7 @@ class TestConfig:
         with open(".scuba.yml", "w") as f:
             f.write("image: !from_yaml .gitlab.yml image\n")
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "dummian:8.2"
 
     def test_load_config_image_from_yaml_nested_keys(self) -> None:
@@ -177,7 +181,7 @@ class TestConfig:
         with open(".scuba.yml", "w") as f:
             f.write("image: !from_yaml .gitlab.yml somewhere.down.here\n")
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "dummian:8.2"
 
     def test_load_config_image_from_yaml_nested_keys_with_escaped_characters(
@@ -192,7 +196,7 @@ class TestConfig:
         with open(".scuba.yml", "w") as f:
             f.write('image: !from_yaml .gitlab.yml "\\.its.somewhere\\.down.here"\n')
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "dummian:8.2"
 
     def test_load_config_from_yaml_cached_file(self) -> None:
@@ -213,7 +217,7 @@ class TestConfig:
             f.write("    script: ugh\n")
 
         with mock_open() as m:
-            config = scuba.config.load_config(".scuba.yml")
+            config = load_config()
 
         # Assert that .gitlab.yml was only opened once
         assert m.mock_calls == [
@@ -247,7 +251,7 @@ class TestConfig:
         with open(".scuba.yml", "w") as f:
             f.write("image: !from_yaml .gitlab.yml 𝕦𝕟𝕚𝕔𝕠𝕕𝕖\n")
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.image == "𝕨𝕠𝕣𝕜𝕤:𝕠𝕜"
 
     def test_load_config_image_from_yaml_missing_arg(self) -> None:
@@ -268,7 +272,7 @@ class TestConfig:
 
         pat = "could not determine a constructor for the tag.*python/object/apply"
         with pytest.raises(scuba.config.ConfigError, match=pat) as ctx:
-            scuba.config.load_config(".scuba.yml")
+            load_config()
 
     def test_load_config_safe(self) -> None:
         """load_config safely loads yaml"""
@@ -299,7 +303,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
 
         assert config.hooks.get("root") == [
             'echo "This runs before we switch users"',
@@ -372,7 +376,7 @@ class TestConfig:
         monkeypatch.setenv("EXTERNAL", "Outside world")
         monkeypatch.delenv("EXTERNAL_NOTSET", raising=False)
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
 
         expect = dict(
             FOO="This is foo",
@@ -408,7 +412,7 @@ class TestConfig:
         monkeypatch.setenv("EXTERNAL", "Outside world")
         monkeypatch.delenv("EXTERNAL_NOTSET", raising=False)
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
 
         expect = dict(
             FOO="This is foo",
@@ -437,7 +441,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
 
         assert config.aliases["al"].environment == dict(
             FOO="Overridden",
@@ -456,7 +460,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.entrypoint is None
 
     def test_entrypoint_null(self) -> None:
@@ -469,7 +473,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.entrypoint == ""  # Null => empty string
 
     def test_entrypoint_invalid(self) -> None:
@@ -494,7 +498,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.entrypoint == ""
 
     def test_entrypoint_set(self) -> None:
@@ -507,7 +511,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.entrypoint == "my_ep"
 
     def test_alias_entrypoint_null(self) -> None:
@@ -525,7 +529,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].entrypoint == ""  # Null => empty string
 
     def test_alias_entrypoint_empty_string(self) -> None:
@@ -543,7 +547,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].entrypoint == ""
 
     def test_alias_entrypoint(self) -> None:
@@ -561,7 +565,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].entrypoint == "use_this_ep"
 
     ############################################################################
@@ -576,7 +580,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.docker_args is None
 
     def test_docker_args_invalid(self) -> None:
@@ -601,7 +605,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.docker_args == []
 
     def test_docker_args_set_empty_string(self) -> None:
@@ -614,7 +618,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.docker_args == []  # '' -> [] after shlex.split()
 
     def test_docker_args_set(self) -> None:
@@ -627,7 +631,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.docker_args == ["--privileged"]
 
     def test_docker_args_set_multi(self) -> None:
@@ -640,7 +644,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.docker_args == ["--privileged", "-v", "/tmp/:/tmp/"]
 
     def test_alias_docker_args_null(self) -> None:
@@ -658,7 +662,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == []
 
     def test_alias_docker_args_empty_string(self) -> None:
@@ -676,7 +680,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == []
 
     def test_alias_docker_args_set(self) -> None:
@@ -694,7 +698,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
 
     def test_alias_docker_args_override(self) -> None:
@@ -712,7 +716,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
         assert isinstance(
             config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
@@ -733,7 +737,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == []
         assert isinstance(
             config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
@@ -757,7 +761,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
         assert isinstance(
             config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
@@ -781,7 +785,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.aliases["testalias"].docker_args == ["-v", "/tmp/:/tmp/"]
         assert isinstance(
             config.aliases["testalias"].docker_args, scuba.config.OverrideMixin
@@ -799,7 +803,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.volumes is None
 
     def test_volumes_null(self) -> None:
@@ -812,7 +816,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.volumes == None
 
     def test_volumes_invalid(self) -> None:
@@ -883,7 +887,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         assert config.volumes is not None
         assert len(config.volumes) == 1
 
@@ -907,7 +911,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         vols = config.volumes
         assert vols is not None
         assert len(vols) == 3
@@ -948,7 +952,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         vols = config.aliases["testalias"].volumes
         assert vols is not None
         assert len(vols) == 2
@@ -978,7 +982,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         vols = config.volumes
         assert vols is not None
         assert len(vols) == 1
@@ -1009,7 +1013,7 @@ class TestConfig:
                 """
             )
 
-        config = scuba.config.load_config(".scuba.yml")
+        config = load_config()
         vols = config.volumes
         assert vols is not None
         assert len(vols) == 3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -892,9 +892,7 @@ class TestConfig:
         assert config.volumes is not None
         assert len(config.volumes) == 1
 
-        v = config.volumes["/cpath"]
-        assert v.container_path == "/cpath"
-        assert v.host_path == "/hpath"
+        assert_vol(config.volumes, "/cpath", "/hpath")
 
     def test_volumes_complex(self) -> None:
         """volumes can be set using the complex form"""
@@ -917,23 +915,9 @@ class TestConfig:
         assert vols is not None
         assert len(vols) == 3
 
-        v = vols["/foo"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/foo"
-        assert v.host_path == "/host/foo"
-        assert v.options == []
-
-        v = vols["/bar"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/bar"
-        assert v.host_path == "/host/bar"
-        assert v.options == []
-
-        v = vols["/snap"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/snap"
-        assert v.host_path == "/host/snap"
-        assert v.options == ["z", "ro"]
+        assert_vol(vols, "/foo", "/host/foo")
+        assert_vol(vols, "/bar", "/host/bar")
+        assert_vol(vols, "/snap", "/host/snap", ["z", "ro"])
 
     def test_alias_volumes_set(self) -> None:
         """docker_args can be set via alias"""
@@ -958,17 +942,8 @@ class TestConfig:
         assert vols is not None
         assert len(vols) == 2
 
-        v = vols["/foo"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/foo"
-        assert v.host_path == "/host/foo"
-        assert v.options == []
-
-        v = vols["/bar"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/bar"
-        assert v.host_path == "/host/bar"
-        assert v.options == ["z", "ro"]
+        assert_vol(vols, "/foo", "/host/foo")
+        assert_vol(vols, "/bar", "/host/bar", ["z", "ro"])
 
     def test_volumes_with_env_vars_simple(self, monkeypatch) -> None:
         """volume definitions can contain environment variables"""
@@ -988,11 +963,7 @@ class TestConfig:
         assert vols is not None
         assert len(vols) == 1
 
-        v = list(vols.values())[0]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/bar/baz/foo"
-        assert v.host_path == "/moo/doo/foo"
-        assert v.options == []
+        assert_vol(vols, "/bar/baz/foo", "/moo/doo/foo")
 
     def test_volumes_with_env_vars_complex(self, monkeypatch) -> None:
         """complex volume definitions can contain environment variables"""
@@ -1019,23 +990,11 @@ class TestConfig:
         assert vols is not None
         assert len(vols) == 3
 
-        v = vols["/home/testuser/.config"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/home/testuser/.config"
-        assert v.host_path == "/home/testuser/.config"
-        assert v.options == []
-
-        v = vols["/tmp/"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/tmp/"
-        assert v.host_path == "/home/testuser/scuba/myproject/tmp"
-        assert v.options == []
-
-        v = vols["/var/spool/mail/container"]
-        assert isinstance(v, scuba.config.ScubaVolume)
-        assert v.container_path == "/var/spool/mail/container"
-        assert v.host_path == "/var/spool/mail/testuser"
-        assert v.options == ["z", "ro"]
+        assert_vol(vols, "/home/testuser/.config", "/home/testuser/.config")
+        assert_vol(vols, "/tmp", "/home/testuser/scuba/myproject/tmp")
+        assert_vol(
+            vols, "/var/spool/mail/container", "/var/spool/mail/testuser", ["z", "ro"]
+        )
 
     def test_volumes_with_invalid_env_vars(self, monkeypatch) -> None:
         """Volume definitions cannot include unset env vars"""

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -2,6 +2,7 @@
 from unittest import mock
 import pytest
 
+from pathlib import Path
 import subprocess
 from typing import Sequence
 from .const import *
@@ -106,15 +107,21 @@ def test_get_image_entrypoint__none() -> None:
 
 
 def test_make_vol_opt_no_opts() -> None:
-    assert uut.make_vol_opt("/hostdir", "/contdir") == "--volume=/hostdir:/contdir"
+    assert (
+        uut.make_vol_opt(Path("/hostdir"), Path("/contdir"))
+        == "--volume=/hostdir:/contdir"
+    )
 
 
 def test_make_vol_opt_empty_opts() -> None:
-    assert uut.make_vol_opt("/hostdir", "/contdir", []) == "--volume=/hostdir:/contdir"
+    assert (
+        uut.make_vol_opt(Path("/hostdir"), Path("/contdir"), [])
+        == "--volume=/hostdir:/contdir"
+    )
 
 
 def test_make_vol_opt_multi_opts() -> None:
     assert (
-        uut.make_vol_opt("/hostdir", "/contdir", ["ro", "z"])
+        uut.make_vol_opt(Path("/hostdir"), Path("/contdir"), ["ro", "z"])
         == "--volume=/hostdir:/contdir:ro,z"
     )

--- a/tests/test_scuba.py
+++ b/tests/test_scuba.py
@@ -1,5 +1,6 @@
 import pytest
 import shlex
+from .utils import assert_vol
 
 from scuba.config import ScubaConfig, ConfigError, OverrideStr
 from scuba.scuba import ScubaContext
@@ -340,13 +341,8 @@ class TestScubaContext:
         vols = result.volumes
         assert len(vols) == 2
 
-        v = vols["/foo"]
-        assert v.container_path == "/foo"
-        assert v.host_path == "/host/foo"
-
-        v = vols["/bar"]
-        assert v.container_path == "/bar"
-        assert v.host_path == "/host/bar"
+        assert_vol(vols, "/foo", "/host/foo")
+        assert_vol(vols, "/bar", "/host/bar")
 
     def test_process_command_alias_updates_volumes(self) -> None:
         """aliases can extend the volumes"""
@@ -370,6 +366,4 @@ class TestScubaContext:
         vols = result.volumes
         assert len(vols) == 1
 
-        v = vols["/foo"]
-        assert v.container_path == "/foo"
-        assert v.host_path == "/alternate/foo"
+        assert_vol(vols, "/foo", "/alternate/foo")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,15 +32,6 @@ def make_executable(path: PathStr) -> None:
     os.chmod(path, mode)
 
 
-def mock_open():
-    real_open = open
-
-    def mocked_open(*args, **kwargs):
-        return real_open(*args, **kwargs)
-
-    return mock.patch("builtins.open", side_effect=mocked_open)
-
-
 # http://stackoverflow.com/a/8389373/119527
 class PseudoTTY:
     def __init__(self, underlying):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,8 +6,10 @@ import shutil
 import unittest
 import logging
 from pathlib import Path
-from typing import Any, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
 from unittest import mock
+
+from scuba.config import ScubaVolume
 
 PathStr = Union[Path, str]
 
@@ -24,6 +26,21 @@ def assert_str_equalish(exp: Any, act: Any) -> None:
     exp = str(exp).strip()
     act = str(act).strip()
     assert exp == act
+
+
+def assert_vol(
+    vols: Dict[Path, ScubaVolume],
+    cpath_str: str,
+    hpath_str: str,
+    options: List[str] = [],
+) -> None:
+    cpath = Path(cpath_str)
+    hpath = Path(hpath_str)
+    v = vols[cpath]
+    assert isinstance(v, ScubaVolume)
+    assert v.container_path == cpath
+    assert v.host_path == hpath
+    assert v.options == options
 
 
 def make_executable(path: PathStr) -> None:


### PR DESCRIPTION
[`pathlib.Path`](https://docs.python.org/3/library/pathlib.html), added in Python 3.4, is a welcome improvement to many places in Scuba, making it clear when objects are paths, and making many path manipulation actions much simpler.