### PR TITLE
Enable use of relative volume host-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Enable the use of relative paths in a volume hostpath (#227)
+
+
 ## [2.11.0] - 2023-09-09
 ### Changed
 - Introduced `pyproject.toml` and moved metadata from `setup.py` (#211)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -145,8 +145,8 @@ style <https://yaml.org/spec/1.2/spec.html#id2788097>`_:
 ``volumes``
 -----------
 
-The optional ``volumes`` node *(added in v2.9.0)* allows additional `volumes
-<https://docs.docker.com/storage/volumes/>`_ or bind-mounts to be specified.
+The optional ``volumes`` node *(added in v2.9.0)* allows additional
+`bind-mounts<https://docs.docker.com/storage/bind-mounts/>`_ to be specified.
 ``volumes`` is a mapping (dictionary) where each key is the container-path.
 In the simple form, the value is a string, the host-path to be bind-mounted:
 
@@ -154,6 +154,7 @@ In the simple form, the value is a string, the host-path to be bind-mounted:
 
     volumes:
       /var/lib/foo: /host/foo
+      /var/lib/bar: ./bar
 
 In the complex form, the value is a mapping which must contain a ``hostpath``
 subkey. It can also contain an ``options`` subkey with a comma-separated list
@@ -178,6 +179,11 @@ directory into the container at the same path.
 
 If a referenced environment variable is not set, Scuba exits with a
 configuration error.
+
+Volume container paths must be absolute.
+
+Volume host paths can be absolute or relative. If a relative path is used, it
+is interpreted as relative to the directory in which ``.scuba.yml`` is found.
 
 Volume host directories which do not already exist are created as the current
 user before creating the container.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -184,6 +184,7 @@ Volume container paths must be absolute.
 
 Volume host paths can be absolute or relative. If a relative path is used, it
 is interpreted as relative to the directory in which ``.scuba.yml`` is found.
+To avoid ambiguity, relative paths must start with ``./`` or ``../``.
 
 Volume host directories which do not already exist are created as the current
 user before creating the container.

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -332,7 +332,7 @@ def _get_volumes(
 
     vols = {}
     for cpath_str, v in voldata.items():
-        cpath = _expand_path(cpath_str)
+        cpath = _expand_path(cpath_str)  # no base_dir; container path must be absolute.
         vols[cpath] = ScubaVolume.from_dict(cpath, v, scuba_root)
     return vols
 
@@ -405,7 +405,7 @@ class ScubaVolume:
         if isinstance(node, str):
             return cls(
                 container_path=cpath,
-                host_path=_expand_path(node),
+                host_path=_expand_path(node, scuba_root),
             )
 
         # Complex form
@@ -419,7 +419,7 @@ class ScubaVolume:
                 raise ConfigError(f"Volume {cpath} must have a 'hostpath' subkey")
             return cls(
                 container_path=cpath,
-                host_path=_expand_path(hpath),
+                host_path=_expand_path(hpath, scuba_root),
                 options=_get_delimited_str_list(node, "options", ","),
             )
 

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -468,7 +468,10 @@ class ScubaConfig:
     hooks: Dict[str, List[str]]
     environment: Environment
 
-    def __init__(self, **data: CfgNode) -> None:
+    def __init__(self, data: Optional[dict[str, CfgNode]] = None) -> None:
+        if data is None:
+            data = {}
+
         optional_nodes = (
             "image",
             "aliases",
@@ -532,4 +535,4 @@ def load_config(path: Path) -> ScubaConfig:
     except yaml.YAMLError as e:
         raise ConfigError(f"Error loading {SCUBA_YML}: {e}")
 
-    return ScubaConfig(**(data or {}))
+    return ScubaConfig(data)

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -137,6 +137,11 @@ def make_vol_opt(
     options: Optional[Sequence[str]] = None,
 ) -> str:
     """Generate a docker volume option"""
+    if not hostdir.is_absolute():
+        raise ValueError(f"hostdir not absolute: {hostdir}")
+    if not contdir.is_absolute():
+        raise ValueError(f"contdir not absolute: {contdir}")
+
     vol = f"--volume={hostdir}:{contdir}"
     if options:
         assert not isinstance(options, str)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1104,6 +1104,25 @@ class TestConfig:
             )
         self._invalid_config("Relative path must start with ./ or ../")
 
+    def test_volumes_hostpath_rel_in_env(self, monkeypatch, in_tmp_path) -> None:
+        """volume definitions can contain environment variables, including relative path portions"""
+        monkeypatch.setenv("PREFIX", "./")
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                r"""
+                image: na
+                volumes:
+                  /foo: ${PREFIX}/foo
+                """
+            )
+
+        config = load_config()
+        vols = config.volumes
+        assert vols is not None
+        assert len(vols) == 1
+
+        assert_vol(vols, "/foo", in_tmp_path / "foo")
+
     def test_volumes_contpath_rel(self, monkeypatch, in_tmp_path) -> None:
         with open(".scuba.yml", "w") as f:
             f.write(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ import scuba.config
 
 
 def load_config() -> scuba.config.ScubaConfig:
-    return scuba.config.load_config(Path(".scuba.yml"))
+    return scuba.config.load_config(Path(".scuba.yml"), Path.cwd())
 
 
 class TestCommonScriptSchema:

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -125,3 +125,8 @@ def test_make_vol_opt_multi_opts() -> None:
         uut.make_vol_opt(Path("/hostdir"), Path("/contdir"), ["ro", "z"])
         == "--volume=/hostdir:/contdir:ro,z"
     )
+
+
+def test_make_vol_opt__requires_absolute() -> None:
+    with pytest.raises(ValueError):
+        uut.make_vol_opt(Path("hostdir"), Path("/contdir"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1065,3 +1065,30 @@ class TestMain:
             )
 
         self.run_scuba(["touch", "/userdir/test.txt"], 128)
+
+    def test_volumes_host_path_rel(self) -> None:
+        """Volume host paths can be relative"""
+
+        # Set up a subdir with a file to be read.
+        userdir = Path("./user")
+        userdir.mkdir(parents=True)
+
+        test_message = "Relative paths work"
+        (userdir / "test.txt").write_text(test_message)
+
+        with open(".scuba.yml", "w") as f:
+            f.write(
+                f"""
+                image: {DOCKER_IMAGE}
+                volumes:
+                  /userdir: {userdir}
+                """
+            )
+
+        # Invoke scuba from a different subdir, for good measure.
+        otherdir = Path("way/down/here")
+        otherdir.mkdir(parents=True)
+        os.chdir(otherdir)
+
+        out, _ = self.run_scuba(["cat", "/userdir/test.txt"])
+        assert out == test_message

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1081,7 +1081,7 @@ class TestMain:
                 f"""
                 image: {DOCKER_IMAGE}
                 volumes:
-                  /userdir: {userdir}
+                  /userdir: ./{userdir}
                 """
             )
 

--- a/tests/test_scuba.py
+++ b/tests/test_scuba.py
@@ -1,9 +1,16 @@
 import pytest
 import shlex
+from typing import Any
 from .utils import assert_vol
 
 from scuba.config import ScubaConfig, ConfigError, OverrideStr
 from scuba.scuba import ScubaContext
+
+
+# This exists simply to adapt all of the existing, simple kwargs-style callers
+# to the new one-dict argument ScubaConfig.__init__().
+def make_config(**data: Any) -> ScubaConfig:
+    return ScubaConfig(data)
 
 
 class TestScubaContext:
@@ -12,7 +19,7 @@ class TestScubaContext:
         image_name = "test_image"
         entrypoint = "test_entrypoint"
 
-        cfg = ScubaConfig(
+        cfg = make_config(
             image=image_name,
             entrypoint=entrypoint,
         )
@@ -22,7 +29,7 @@ class TestScubaContext:
 
     def test_process_command_empty(self) -> None:
         """process_command handles no aliases and an empty command"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
         )
         result = ScubaContext.process_command(cfg, [])
@@ -30,7 +37,7 @@ class TestScubaContext:
 
     def test_process_command_no_aliases(self) -> None:
         """process_command handles no aliases"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
         )
         result = ScubaContext.process_command(cfg, ["cmd", "arg1", "arg2"])
@@ -41,7 +48,7 @@ class TestScubaContext:
 
     def test_process_command_aliases_unused(self) -> None:
         """process_command handles unused aliases"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
             aliases=dict(
                 apple="banana",
@@ -56,7 +63,7 @@ class TestScubaContext:
 
     def test_process_command_aliases_used_noargs(self) -> None:
         """process_command handles aliases with no args"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
             aliases=dict(
                 apple="banana",
@@ -71,7 +78,7 @@ class TestScubaContext:
 
     def test_process_command_aliases_used_withargs(self) -> None:
         """process_command handles aliases with args"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
             aliases=dict(
                 apple='banana cherry "pie is good"',
@@ -88,7 +95,7 @@ class TestScubaContext:
 
     def test_process_command_multiline_aliases_used(self) -> None:
         """process_command handles multiline aliases"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
             aliases=dict(
                 apple=dict(
@@ -109,7 +116,7 @@ class TestScubaContext:
 
     def test_process_command_multiline_aliases_forbid_user_args(self) -> None:
         """process_command raises ConfigError when args are specified with multiline aliases"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="na",
             aliases=dict(
                 apple=dict(
@@ -126,7 +133,7 @@ class TestScubaContext:
 
     def test_process_command_alias_overrides_image(self) -> None:
         """aliases can override the image"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             aliases=dict(
                 apple=dict(
@@ -143,7 +150,7 @@ class TestScubaContext:
 
     def test_process_command_alias_overrides_image_and_entrypoint(self) -> None:
         """aliases can override the image and entrypoint"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             entrypoint="default_entrypoint",
             aliases=dict(
@@ -163,7 +170,7 @@ class TestScubaContext:
 
     def test_process_command_alias_overrides_image_and_empty_entrypoint(self) -> None:
         """aliases can override the image and empty/null entrypoint"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             entrypoint="default_entrypoint",
             aliases=dict(
@@ -185,7 +192,7 @@ class TestScubaContext:
         """process_command allows image to be overridden when provided"""
         override_image_name = "override_image"
 
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="test_image",
         )
         result = ScubaContext.process_command(
@@ -197,7 +204,7 @@ class TestScubaContext:
         """process_command allows image to be overridden when not provided"""
         override_image_name = "override_image"
 
-        cfg = ScubaConfig()
+        cfg = make_config()
         result = ScubaContext.process_command(
             cfg, [], image_override=override_image_name
         )
@@ -207,7 +214,7 @@ class TestScubaContext:
         """process_command allows image to be overridden when provided by alias"""
         override_image_name = "override_image"
 
-        cfg = ScubaConfig(
+        cfg = make_config(
             aliases=dict(
                 apple=dict(
                     script=[
@@ -225,7 +232,7 @@ class TestScubaContext:
 
     def test_env_merge(self) -> None:
         """process_command merges/overrides the environment from the alias"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="dontcare",
             environment=dict(
                 AAA="aaa_base",
@@ -251,7 +258,7 @@ class TestScubaContext:
 
     def test_process_command_alias_extends_docker_args(self) -> None:
         """aliases can extend the docker_args"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             docker_args="--privileged",
             aliases=dict(
@@ -268,7 +275,7 @@ class TestScubaContext:
 
     def test_process_command_alias_overrides_docker_args(self) -> None:
         """aliases can override the docker_args"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             docker_args="--privileged",
             aliases=dict(
@@ -285,7 +292,7 @@ class TestScubaContext:
 
     def test_process_command_alias_overrides_docker_args_with_empty(self) -> None:
         """aliases can override the docker_args"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             docker_args="--privileged",
             aliases=dict(
@@ -302,7 +309,7 @@ class TestScubaContext:
 
     def test_process_command_alias_inherits_top_docker_args(self) -> None:
         """aliases inherit the top-level docker_args if not specified"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             docker_args="--privileged",
             aliases=dict(
@@ -321,7 +328,7 @@ class TestScubaContext:
 
     def test_process_command_alias_extends_volumes(self) -> None:
         """aliases can extend the volumes"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             volumes={
                 "/foo": "/host/foo",
@@ -346,7 +353,7 @@ class TestScubaContext:
 
     def test_process_command_alias_updates_volumes(self) -> None:
         """aliases can extend the volumes"""
-        cfg = ScubaConfig(
+        cfg = make_config(
             image="default",
             volumes={
                 "/foo": "/host/foo",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,15 @@ def assert_seq_equal(a: Sequence, b: Sequence) -> None:
 
 
 def assert_paths_equal(a: PathStr, b: PathStr) -> None:
+    # NOTE: normpath() can behave undesirably in the face of symlinks, so this
+    # comparison is probably not perfect. But since we're often dealing with
+    # "pure" paths (that don't actually exist on the filesystem), there's not
+    # much more we can do.
+    #
+    # "This string manipulation may change the meaning of a path that contains
+    # symbolic links."
+    #
+    # https://docs.python.org/3/library/os.path.html#os.path.normpath
     assert normpath(a) == normpath(b)
 
 
@@ -38,8 +47,8 @@ def assert_vol(
     hpath = Path(hpath_str)
     v = vols[cpath]
     assert isinstance(v, ScubaVolume)
-    assert v.container_path == cpath
-    assert v.host_path == hpath
+    assert_paths_equal(v.container_path, cpath)
+    assert_paths_equal(v.host_path, hpath)
     assert v.options == options
 
 


### PR DESCRIPTION
This enables the use of relative paths in a volume hostpath.

Previously, if one put this in `.scuba.yml`:
```yml
volumes:
    /foo: foo
    # or
    /foo:
        hostpath: foo
```
`foo` would be interpreted by Docker as a *named volume*, resulting in an empty directory at `/foo`, which is certainly not what the user intended.

Or, if one tried to work around that problem and do this:
```yml
volumes:
    /foo: ./foo
```
Then Docker would complain about the use of a relative path (a specifier containing a `/` but not starting with `/`), and suggest the use of an absolute path.

Now, when scuba encounters a relative path in a volume `hostpath`, it is interpreted as **relative to the scuba root** (the directory in which `.scbua.yml` is found). To avoid ambiguity with the old behavior, *relative paths must start with `./` or `../`*.

I also considered interpreting relative paths as relative to the current working directory, but that seemed like a much less useful approach:
- The common scenario would be to mount a project folder somewhere else in the filesystem:
  ```yml
  volumes:
    /var/cualqomm/license:
        hostpath: ./cq_license
  ```
- I can't think of a scenario where I would want a bind mount (to a fixed container-path) to change depending on where my current directory is within my project tree.
  - If this was truly desired, one could use `$PWD/foo`.
- The scheme whereby relative paths in config files are relative to the directory containing the config file is intuitive and widely-used:
  - In Scuba
    - `!from_yaml` ([ref](https://scuba.readthedocs.io/en/latest/configuration.html#accessing-external-yaml-content:~:text=The%20path%20of%20an%20external%20YAML%20file%20(relative%20to%20.scuba.yaml)))
  - In `.gitconfig` ([ref](https://git-scm.com/docs/git-config#:~:text=If%20the%20value%20of%20the%20variable%20is%20a%20relative%20path%2C%20the%20path%20is%20considered%20to%20be%20relative%20to%20the%20configuration%20file%20in%20which%20the%20include%20directive%20was%20found))
  - In ADMan config ([ref](https://adman.readthedocs.io/en/latest/configuration.html#types:~:text=path%20%E2%80%93%20A%20YAML%20string%3B%20the%20path%20to%20a%20file.%20The%20path%20can%20either%20be%20absolute%20(start%20with%20a%20leading%20/)%2C%20or%20relative%20to%20the%20directory%20containing%20the%20config.yml%20file.))
  - In Docker Compose:
    - `env_file` ([ref](https://docs.docker.com/compose/compose-file/05-services/#env_file:~:text=Relative%20path%20are%20resolved%20from%20the%20Compose%20file%27s%20parent%20folder.))
    - `extends.file` ([ref](https://docs.docker.com/compose/compose-file/05-services/#extends:~:text=Relative%20path.%20This%20path%20is%20considered%20as%20relative%20to%20the%20location%20of%20the%20main%20Compose%20file.))
    - service volumes ([ref](https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5:~:text=the%20relative%20path%20is%20resolved%20from%20the%20Compose%20file%E2%80%99s%20parent%20directory))


Fixes #218