### PR TITLE
Set build.os in .readthedocs.yml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,11 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
 sphinx:
   configuration: docs/conf.py
 


### PR DESCRIPTION
This is now required, apparently.

See:
- https://github.com/readthedocs/readthedocs.org/issues/8861#issuecomment-1025568797
- https://github.com/readthedocs/readthedocs.org/issues/8912

This fixes the error seen here:
https://readthedocs.org/projects/scuba/builds/22812400/

> Problem in your project's configuration. Invalid configuration option "build.os": build not found

