### PR TITLE
Add explicit support for mounting named volumes

### DIFF
--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -132,17 +132,22 @@ def get_image_entrypoint(image: str) -> Optional[Sequence[str]]:
 
 
 def make_vol_opt(
-    hostdir: Path,
+    hostdir_or_volname: Union[Path, str],
     contdir: Path,
     options: Optional[Sequence[str]] = None,
 ) -> str:
     """Generate a docker volume option"""
-    if not hostdir.is_absolute():
-        raise ValueError(f"hostdir not absolute: {hostdir}")
+    if isinstance(hostdir_or_volname, Path):
+        hostdir: Path = hostdir_or_volname
+        if not hostdir.is_absolute():
+            # NOTE: As of Docker Engine version 23, you can use relative paths
+            # on the host. But we have no minimum Docker version, so we don't
+            # rely on this.
+            raise ValueError(f"hostdir not absolute: {hostdir}")
     if not contdir.is_absolute():
         raise ValueError(f"contdir not absolute: {contdir}")
 
-    vol = f"--volume={hostdir}:{contdir}"
+    vol = f"--volume={hostdir_or_volname}:{contdir}"
     if options:
         assert not isinstance(options, str)
         vol += ":" + ",".join(options)

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -165,7 +165,7 @@ class ScubaDive:
             return
 
         for vol in self.context.volumes.values():
-            if vol.host_path.exists():
+            if vol.host_path is None or vol.host_path.exists():
                 continue
 
             try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,6 +48,8 @@ def assert_vol(
     v = vols[cpath]
     assert isinstance(v, ScubaVolume)
     assert_paths_equal(v.container_path, cpath)
+    assert v.volume_name is None
+    assert v.host_path is not None
     assert_paths_equal(v.host_path, hpath)
     assert v.options == options
 


### PR DESCRIPTION
Named volumes were unintentionally supported prior to #227. This change restores the prior behavior while remaining unambiguiously compatible with relative bind-mounts added in #227.

This also adds support for explicit named volumes in complex form configuration.

Fixes #248