### PR TITLE
scubainit: Use nightly flag -Zon-broken-pipe=inherit to fix SIGPIPE

### DIFF
--- a/run_full_tests.py
+++ b/run_full_tests.py
@@ -36,6 +36,7 @@ def test1():
             f.write(in_data)
 
         subprocess.check_call(["scuba", "/bin/sh", "-c", "cat file.in >> file.out"])
+        subprocess.check_call(["scuba", "/bin/sh", "-c", "yes '' | echo 'test'"])
 
         with open("file.out", "rt") as f:
             out_data = f.read()

--- a/scubainit/Makefile
+++ b/scubainit/Makefile
@@ -23,6 +23,7 @@ TARGET=x86_64-unknown-linux-musl
 
 # Enable static linking
 STATIC_RUSTFLAGS=-C relocation-model=static
+NIGHTLY_RUSTFLAGS=-Zon-broken-pipe=inherit
 
 export RUSTFLAGS
 
@@ -43,7 +44,7 @@ fmt:
 
 .PHONY: scubainit-debug  # always build
 scubainit-debug: PROFILE=debug
-scubainit-debug: RUSTFLAGS=$(STATIC_RUSTFLAGS)
+scubainit-debug: RUSTFLAGS=$(STATIC_RUSTFLAGS) $(NIGHTLY_RUSTFLAGS)
 scubainit-debug: setup
 	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) with RUSTFLAGS=\"$$RUSTFLAGS\""
 	cargo build --target $(TARGET)
@@ -51,7 +52,7 @@ scubainit-debug: setup
 
 .PHONY: scubainit  # always build
 scubainit: PROFILE=release
-scubainit: RUSTFLAGS=$(STATIC_RUSTFLAGS)
+scubainit: RUSTFLAGS=$(STATIC_RUSTFLAGS) $(NIGHTLY_RUSTFLAGS)
 scubainit: setup
 	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) with RUSTFLAGS=\"$$RUSTFLAGS\""
 	cargo build --target $(TARGET) --release

--- a/scubainit/rust-toolchain.toml
+++ b/scubainit/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-05-07"
+targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Rust ignores SIGPIPE by default, this patch overrides that behaviour to fix this by *not* panic'ing on Broken pipes and restore old scubainit behavior.

In short, the following fails:
> image: debian:latest
>
> aliases:
>  test: yes '' | echo "test"

$ scuba test:
> test
> yes: standard output: Broken pipe

* Use nightly on-broken-pipe="inherit" to inherit the behavior from the parent process, Instead of killing our process. See docs here: https://github.com/rust-lang/rust/blob/master/src/doc/unstable-book/src/compiler-flags/on-broken-pipe.md This nightly fix is definitely unstable(with very recent API changes), but hopefully they keep this interface as a compiler option the same until stabilization.

* Add test to verify this doesn't break in the future

* Add rust-toolchain.toml to define the locked rust version since this requires a nightly option. I specifically didn't think nightly was an issue, since you were looking into using -Zbuild-std for scubainit size minimization (which has a long path to stabilization)

This has been a longstanding issue for the Rust language:
- https://github.com/rust-lang/rust/issues/62569
- https://github.com/rust-lang/rust/issues/97889