### PR TITLE
scubainit: Restore the default SIGPIPE action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fixed SIGPIPE disposition being set to ignore (#255)
+
 ## [2.13.0] - 2024-03-25
 ### Added
 - Added support for Python 3.12 (#244)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -278,6 +278,17 @@ class TestMainStdinStdout(MainTest):
         assert_str_equalish(out, test_str)
 
 
+class TestMainSignals(MainTest):
+    def test_sigpipe(self) -> None:
+        """Verify SIGPIPE is handled correctly"""
+        # See https://github.com/JonathonReinhart/scuba/issues/254
+        SCUBA_YML.write_text(f"image: {DOCKER_IMAGE}")
+
+        out, err = run_scuba(["sh", "-c", "yes | echo abcd"])
+        assert_str_equalish(out, "abcd")
+        assert_str_equalish(err, "")
+
+
 class TestMainUser(MainTest):
     def _test_user(
         self,


### PR DESCRIPTION
Rust pre-main code may change the SIGPIPE disposition to ignore:
* https://github.com/rust-lang/rust/issues/62569
* https://github.com/rust-lang/rust/issues/97889

We could use the nightly compiler flag `-Zon-broken-pipe=inherit` to disable this behavior. Instead, we take the simpler route and restore the default disposition ourselves.

Fixes #254