### PR TITLE
add hotfix for gitlab extensions

### DIFF
--- a/scuba/config.py
+++ b/scuba/config.py
@@ -155,9 +155,12 @@ class Loader(yaml.SafeLoader):
         assert isinstance(obj, OverrideMixin)
         return obj
 
+    def not_yet_implemented(self, node: yaml.nodes.Node):
+        pass
 
 Loader.add_constructor("!from_yaml", Loader.from_yaml)
 Loader.add_constructor("!override", Loader.override)
+Loader.add_constructor("!reference", Loader.not_yet_implemented)
 
 
 def find_config() -> Tuple[Path, Path, ScubaConfig]:
@@ -517,7 +520,7 @@ class ScubaAlias:
             return cls(
                 name=name,
                 script=script,
-                image=node.get("image"),
+                image=_get_str(node, "image"),
                 entrypoint=_get_entrypoint(node),
                 environment=_process_environment(
                     node.get("environment"), f"{name}.environment"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,6 +282,44 @@ class TestLoadConfig(ConfigTest):
         SCUBA_YML.write_text(f"image: !from_yaml {external_yml} danger")
         self.__test_load_config_safe(external_yml)
 
+    def test_load_config_image_name(self) -> None:
+        GITLAB_YML.write_text(
+            """
+            two:
+              stage: build
+              image:
+                name: dummian:8.2
+            """
+        )
+        invalid_config(
+            config_text=f"""
+            aliases:
+              two:
+                image:  !from_yaml {GITLAB_YML} two.image
+                script: rip
+            """
+        )
+
+    def test_load_config_gitlab_extensions(self) -> None:
+        GITLAB_YML.write_text(
+            """
+            include: included.yml
+
+            image: dummian:8.2
+
+            one:
+              image: !reference [another, job, somewhere]
+            
+            two:
+              extends: one
+
+            normal:
+              image: dummian:12
+            """
+        )
+
+        load_config(config_text=f"image: !from_yaml {GITLAB_YML} normal.image")
+
 
 class TestConfigHooks(ConfigTest):
     def test_hooks_mixed(self) -> None:


### PR DESCRIPTION
Fix crashing issue (https://github.com/JonathonReinhart/scuba/issues/229)

Adds a `not_yet_implented` func to 'handle' `!reference` tags from gitlab

I'm currently working on a proper implementation for both of these issue, but this should work as a stop-gap until then.