### PR TITLE
fix gitlab image dict crash

### DIFF
--- a/scuba/config.py
+++ b/scuba/config.py
@@ -517,7 +517,7 @@ class ScubaAlias:
             return cls(
                 name=name,
                 script=script,
-                image=node.get("image"),
+                image=_get_str(node, "image"),
                 entrypoint=_get_entrypoint(node),
                 environment=_process_environment(
                     node.get("environment"), f"{name}.environment"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,6 +282,35 @@ class TestLoadConfig(ConfigTest):
         SCUBA_YML.write_text(f"image: !from_yaml {external_yml} danger")
         self.__test_load_config_safe(external_yml)
 
+    def test_load_config_image_name(self) -> None:
+        """
+        .gitlab-ci.yml supports a long-form `image` specification
+        with `name` and other sub-keys:
+        https://docs.gitlab.com/ee/ci/yaml/#image
+
+        Scuba doesn't currently support that, so make sure we handle
+        this error gracefully.
+
+        TODO(#230): Support this complex `image` format.
+        """
+
+        GITLAB_YML.write_text(
+            """
+            two:
+              stage: build
+              image:
+                name: dummian:8.2
+            """
+        )
+        invalid_config(
+            config_text=f"""
+            aliases:
+              two:
+                image:  !from_yaml {GITLAB_YML} two.image
+                script: rip
+            """
+        )
+
 
 class TestConfigHooks(ConfigTest):
     def test_hooks_mixed(self) -> None:


### PR DESCRIPTION
Use `_get_str` instead of `node.get` to prevent crashing when encountering gitlab dict image. 