### PR TITLE
ci: Update actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results (Python ${{ matrix.python-version }})
         path: unit-test-results.xml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
Not affected by the breaking changes.

Fixes #264