### PR TITLE
tests: Fix mypy issue with pytest.raises()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,9 +164,10 @@ def test_expand_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_expand_missing_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MY_VAR", raising=False)
     # Verify that a KeyError is raised for unset env variables
-    with pytest.raises(KeyError) as kerr:
+    with pytest.raises(KeyError) as exc_info:
         scuba.utils.expand_env_vars("Where is ${MY_VAR}?")
-    assert kerr.value.args[0] == "MY_VAR"
+    key_err: KeyError = exc_info.value
+    assert key_err.args[0] == "MY_VAR"
 
 
 def test_expand_env_vars_dollars() -> None:


### PR DESCRIPTION
Prior to this change, mypy was complaining:

```
tests/test_utils.py:169: error: BaseExcT_co_default? has no attribute "args"  [attr-defined]
```

Apparently, even though `pytest.raises()` is supposed to be generic on the given type parameter, mypy was still unaware that the `ExceptionInfo.value` property had that same type.

Adding a type hint takes care of the issue.

Fixes #266