### PR TITLE
Use type hinting generics from standard collections

### DIFF
--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import subprocess
 import json
-from typing import Any, Dict, IO, Optional, Sequence, Union
+from typing import Any, IO, Optional, Sequence, Union
 from pathlib import Path
 
 # https://github.com/python/typeshed/blob/main/stdlib/subprocess.pyi
@@ -41,7 +41,7 @@ def call(
 def _run_docker(*args: str, capture: bool = False) -> subprocess.CompletedProcess[str]:
     """Run docker and raise DockerExecuteError on ENOENT"""
     docker_args = ["docker"] + list(args)
-    kw: Dict[str, Any] = dict(text=True)
+    kw: dict[str, Any] = dict(text=True)
     if capture:
         kw.update(capture_output=True)
 
@@ -89,7 +89,7 @@ def docker_inspect_or_pull(image: str) -> dict:
 def get_images() -> Sequence[str]:
     """Get the current list of docker images
 
-    Returns: List of image names
+    Returns: A list of image names
     """
     cp = _run_docker(
         "images",

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -9,7 +9,7 @@ import tempfile
 from grp import getgrgid
 from pathlib import Path
 from pwd import getpwuid
-from typing import cast, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import cast, Any, Iterable, Optional, Sequence, Union
 from typing import TextIO
 
 from .config import ScubaConfig, OverrideMixin
@@ -19,7 +19,7 @@ from .dockerutil import get_image_entrypoint
 from .dockerutil import make_vol_opt
 from .utils import shell_quote_cmd, flatten_list, get_umask, writeln
 
-VolumeTuple = Tuple[Path, Path, List[str]]
+VolumeTuple = tuple[Path, Path, list[str]]
 
 
 class ScubaError(Exception):
@@ -28,21 +28,21 @@ class ScubaError(Exception):
 
 class ScubaDive:
     context: ScubaContext
-    env_vars: Dict[str, str]
-    volumes: List[VolumeTuple]
-    options: List[str]
-    docker_args: List[str]
+    env_vars: dict[str, str]
+    volumes: list[VolumeTuple]
+    options: list[str]
+    docker_args: list[str]
 
-    docker_cmd: List[str]
+    docker_cmd: list[str]
 
     def __init__(
         self,
-        user_command: List[str],
+        user_command: list[str],
         config: ScubaConfig,
         top_path: Path,
         top_rel: Path,
-        docker_args: Optional[List[str]] = None,
-        env: Optional[Dict[str, str]] = None,
+        docker_args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
         as_root: bool = False,
         verbose: bool = False,
         image_override: Optional[str] = None,
@@ -143,7 +143,7 @@ class ScubaDive:
         self,
         hostpath: Union[Path, str],
         contpath: Union[Path, str],
-        options: Optional[List[str]] = None,
+        options: Optional[list[str]] = None,
     ) -> None:
         """Add a volume (bind-mount) to the docker run invocation"""
         hostpath = Path(hostpath)
@@ -375,11 +375,11 @@ class ScubaDive:
 @dataclasses.dataclass
 class ScubaContext:
     image: str
-    environment: Dict[str, str]  # key: value
-    volumes: Dict[Path, ScubaVolume]
+    environment: dict[str, str]  # key: value
+    volumes: dict[Path, ScubaVolume]
     shell: str
-    docker_args: List[str]
-    script: Optional[List[str]] = None  # TODO: drop Optional?
+    docker_args: list[str]
+    script: Optional[list[str]] = None  # TODO: drop Optional?
     entrypoint: Optional[str] = None
     as_root: bool = False
 
@@ -408,7 +408,7 @@ class ScubaContext:
         entrypoint = cfg.entrypoint
         environment = copy.copy(cfg.environment)
         docker_args = copy.copy(cfg.docker_args) or []
-        volumes: Dict[Path, ScubaVolume] = copy.copy(cfg.volumes or {})
+        volumes: dict[Path, ScubaVolume] = copy.copy(cfg.volumes or {})
         as_root = False
 
         if command:
@@ -429,7 +429,7 @@ class ScubaContext:
                     as_root = True
 
                 if isinstance(alias.docker_args, OverrideMixin) or docker_args is None:
-                    docker_args = cast(List[str], alias.docker_args)
+                    docker_args = cast(list[str], alias.docker_args)
                 elif alias.docker_args is not None:
                     docker_args.extend(alias.docker_args)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from tempfile import TemporaryFile, NamedTemporaryFile
 from textwrap import dedent
-from typing import cast, IO, List, Optional, Sequence, TextIO, Tuple
+from typing import cast, IO, Optional, Sequence, TextIO
 from unittest import mock
 import warnings
 
@@ -27,7 +27,7 @@ from .utils import (
     PseudoTTY,
 )
 
-ScubaResult = Tuple[str, str]
+ScubaResult = tuple[str, str]
 
 
 SCUBA_YML = Path(".scuba.yml")
@@ -40,7 +40,7 @@ def write_script(path: Path, text: str) -> None:
 
 
 def run_scuba(
-    args: List[str],
+    args: list[str],
     *,
     expect_return: int = 0,
     mock_isatty: bool = False,
@@ -296,7 +296,7 @@ class TestMainUser(MainTest):
         expected_username: str,
         expected_gid: int,
         expected_groupname: str,
-        scuba_args: List[str] = [],
+        scuba_args: list[str] = [],
     ) -> None:
         SCUBA_YML.write_text(f"image: {DOCKER_IMAGE}")
 
@@ -316,7 +316,7 @@ class TestMainUser(MainTest):
         assert gid == expected_gid
         assert groupname == expected_groupname
 
-    def _test_user_expect_root(self, scuba_args: List[str] = []) -> None:
+    def _test_user_expect_root(self, scuba_args: list[str] = []) -> None:
         return self._test_user(
             expected_uid=0,
             expected_username="root",
@@ -392,7 +392,7 @@ class TestMainUser(MainTest):
 
 
 class TestMainHomedir(MainTest):
-    def _test_home_writable(self, scuba_args: List[str] = []) -> None:
+    def _test_home_writable(self, scuba_args: list[str] = []) -> None:
         SCUBA_YML.write_text(f"image: {DOCKER_IMAGE}")
 
         args = scuba_args + [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,14 +3,14 @@ from itertools import chain
 import os
 import pytest
 import shlex
-from typing import List, Sequence
+from typing import Sequence
 
 from .utils import assert_seq_equal
 
 import scuba.utils
 
 
-def _parse_cmdline(cmdline: str) -> List[str]:
+def _parse_cmdline(cmdline: str) -> list[str]:
     # Strip the formatting and whitespace
     lines = [l.rstrip("\\").strip() for l in cmdline.splitlines()]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ import shutil
 import unittest
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Sequence, TypeVar, Optional, Union
+from typing import Any, Callable, Sequence, TypeVar, Optional, Union
 from unittest import mock
 
 from scuba.config import ScubaVolume
@@ -41,10 +41,10 @@ def assert_str_equalish(exp: Any, act: Any) -> None:
 
 
 def assert_vol(
-    vols: Dict[Path, ScubaVolume],
+    vols: dict[Path, ScubaVolume],
     cpath_str: PathStr,
     hpath_str: PathStr,
-    options: List[str] = [],
+    options: list[str] = [],
 ) -> None:
     cpath = Path(cpath_str)
     hpath = Path(hpath_str)


### PR DESCRIPTION
This eliminates all uses of these members of `typing`:  
`Tuple`, `List`, `Dict`, `Set`, `FrozenSet`, `Type`