### PR TITLE
Use Python 3.10 language features

### DIFF
--- a/scuba/__main__.py
+++ b/scuba/__main__.py
@@ -9,7 +9,7 @@ import shlex
 import itertools
 import argparse
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 try:
     import argcomplete  # type: ignore
@@ -30,7 +30,7 @@ def appmsg(msg: str) -> None:
     print("scuba: " + msg, file=sys.stderr)
 
 
-def parse_scuba_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+def parse_scuba_args(argv: Sequence[str] | None) -> argparse.Namespace:
     def _list_images_completer(**kwargs: Any) -> Sequence[str]:
         return dockerutil.get_images()
 
@@ -177,7 +177,7 @@ def run_scuba(scuba_args: argparse.Namespace) -> int:
         )
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     scuba_args = parse_scuba_args(argv)
 
     try:

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 from pathlib import Path
-from typing import Any, TextIO, TypeVar, overload
+from typing import Any, TextIO, TypeAlias, TypeVar, overload
 
 import yaml
 import yaml.nodes
@@ -14,9 +14,9 @@ from . import utils
 from .constants import DEFAULT_SHELL, SCUBA_YML
 from .dockerutil import make_vol_opt
 
-CfgNode = Any
-CfgData = dict[str, CfgNode]
-Environment = dict[str, str]
+CfgNode: TypeAlias = Any
+CfgData: TypeAlias = dict[str, CfgNode]
+Environment: TypeAlias = dict[str, str]
 _T = TypeVar("_T")
 
 VOLUME_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]+$")

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 from pathlib import Path
-from typing import Any, Optional, TextIO, TypeVar, overload
+from typing import Any, TextIO, TypeVar, overload
 
 import yaml
 import yaml.nodes
@@ -293,7 +293,7 @@ def _process_environment(node: CfgNode, name: str) -> Environment:
     return result
 
 
-def _get_nullable_str(data: dict[str, Any], key: str) -> Optional[str]:
+def _get_nullable_str(data: dict[str, Any], key: str) -> str | None:
     # N.B. We can't use data.get() here, because that might return
     # None, leading to ambiguity between the key being absent or set
     # to a null value.
@@ -318,11 +318,11 @@ def _get_nullable_str(data: dict[str, Any], key: str) -> Optional[str]:
     return value
 
 
-def _get_entrypoint(data: CfgData) -> Optional[str]:
+def _get_entrypoint(data: CfgData) -> str | None:
     return _get_nullable_str(data, "entrypoint")
 
 
-def _get_docker_args(data: CfgData) -> Optional[list[str]]:
+def _get_docker_args(data: CfgData) -> list[str] | None:
     args_str = _get_nullable_str(data, "docker_args")
     if args_str is None:
         return None
@@ -339,16 +339,16 @@ def _get_typed_val(
     data: CfgData,
     key: str,
     type_: type[_T],
-    default: Optional[_T] = None,
-) -> Optional[_T]:
+    default: _T | None = None,
+) -> _T | None:
     v = data.get(key, default)
     if v is not None and not isinstance(v, type_):
         raise ConfigError(f"{key!r} must be a {type_.__name__}, not {type(v).__name__}")
     return v
 
 
-@overload  # When default is None, can return None (Optional).
-def _get_str(data: CfgData, key: str, default: None = None) -> Optional[str]:
+@overload  # When default is None, can return None.
+def _get_str(data: CfgData, key: str, default: None = None) -> str | None:
     ...
 
 
@@ -357,11 +357,11 @@ def _get_str(data: CfgData, key: str, default: str) -> str:
     ...
 
 
-def _get_str(data: CfgData, key: str, default: Optional[str] = None) -> Optional[str]:
+def _get_str(data: CfgData, key: str, default: str | None = None) -> str | None:
     return _get_typed_val(data, key, str, default)
 
 
-def _get_dict(data: CfgData, key: str) -> Optional[dict[str, Any]]:
+def _get_dict(data: CfgData, key: str) -> dict[str, Any] | None:
     return _get_typed_val(data, key, dict)
 
 
@@ -371,8 +371,8 @@ def _get_delimited_str_list(data: CfgData, key: str, sep: str) -> list[str]:
 
 
 def _get_volumes(
-    data: CfgData, scuba_root: Optional[Path]
-) -> Optional[dict[Path, ScubaVolume]]:
+    data: CfgData, scuba_root: Path | None
+) -> dict[Path, ScubaVolume] | None:
     voldata = _get_dict(data, "volumes")
     if voldata is None:
         return None
@@ -385,7 +385,7 @@ def _get_volumes(
     return vols
 
 
-def _absoluteify_path(in_str: str, base_dir: Optional[Path] = None) -> Path:
+def _absoluteify_path(in_str: str, base_dir: Path | None = None) -> Path:
     """Take a path string and make it absolute.
 
     Absolute paths are returned as-is.
@@ -431,8 +431,8 @@ def _absoluteify_path(in_str: str, base_dir: Optional[Path] = None) -> Path:
 @dataclasses.dataclass(frozen=True)
 class ScubaVolume:
     container_path: Path
-    host_path: Optional[Path] = None
-    volume_name: Optional[str] = None
+    host_path: Path | None = None
+    volume_name: str | None = None
     options: list[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -441,7 +441,7 @@ class ScubaVolume:
 
     @classmethod
     def from_dict(
-        cls, cpath: Path, node: CfgNode, scuba_root: Optional[Path]
+        cls, cpath: Path, node: CfgNode, scuba_root: Path | None
     ) -> ScubaVolume:
         # Treat a null node as an empty dict
         if node is None:
@@ -518,18 +518,16 @@ class ScubaVolume:
 class ScubaAlias:
     name: str
     script: list[str]
-    image: Optional[str] = None
-    entrypoint: Optional[str] = None
-    environment: Optional[dict[str, str]] = None
-    shell: Optional[str] = None
+    image: str | None = None
+    entrypoint: str | None = None
+    environment: dict[str, str] | None = None
+    shell: str | None = None
     as_root: bool = False
-    docker_args: Optional[list[str]] = None
-    volumes: Optional[dict[Path, ScubaVolume]] = None
+    docker_args: list[str] | None = None
+    volumes: dict[Path, ScubaVolume] | None = None
 
     @classmethod
-    def from_dict(
-        cls, name: str, node: CfgNode, scuba_root: Optional[Path]
-    ) -> ScubaAlias:
+    def from_dict(cls, name: str, node: CfgNode, scuba_root: Path | None) -> ScubaAlias:
         script = _process_script_node(node, name)
 
         if isinstance(node, dict):  # Rich alias
@@ -552,17 +550,17 @@ class ScubaAlias:
 
 class ScubaConfig:
     shell: str
-    entrypoint: Optional[str]
-    docker_args: Optional[list[str]]  # TODO: drop Optional?
-    volumes: Optional[dict[Path, ScubaVolume]]  # TODO: drop Optional? dict?
+    entrypoint: str | None
+    docker_args: list[str] | None  # TODO: drop None?
+    volumes: dict[Path, ScubaVolume] | None  # TODO: drop None? dict?
     aliases: dict[str, ScubaAlias]
     hooks: dict[str, list[str]]
     environment: Environment
 
     def __init__(
         self,
-        data: Optional[dict[str, CfgNode]] = None,
-        scuba_root: Optional[Path] = None,
+        data: dict[str, CfgNode] | None = None,
+        scuba_root: Path | None = None,
     ) -> None:
         if data is None:
             data = {}
@@ -596,7 +594,7 @@ class ScubaConfig:
         self.environment = _process_environment(data.get("environment"), "environment")
 
     def _load_aliases(
-        self, data: CfgData, scuba_root: Optional[Path]
+        self, data: CfgData, scuba_root: Path | None
     ) -> dict[str, ScubaAlias]:
         aliases = {}
         for name, node in data.get("aliases", {}).items():

--- a/scuba/config.py
+++ b/scuba/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 from pathlib import Path
-from typing import Any, Optional, TextIO, TypeVar, Union, overload
+from typing import Any, Optional, TextIO, TypeVar, overload
 
 import yaml
 import yaml.nodes

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 import subprocess
 import json
-from typing import Any, IO, Optional, Sequence, Union
+from typing import Any, IO, Optional, Sequence
 from pathlib import Path
 
 # https://github.com/python/typeshed/blob/main/stdlib/subprocess.pyi
-_CMD = Union[str, bytes, Sequence[Union[str, bytes]]]
-_FILE = Union[None, int, IO[Any]]
+_CMD = str | bytes | Sequence[str | bytes]
+_FILE = None | int | IO[Any]
 
 
 class DockerError(Exception):
@@ -132,7 +132,7 @@ def get_image_entrypoint(image: str) -> Optional[Sequence[str]]:
 
 
 def make_vol_opt(
-    hostdir_or_volname: Union[Path, str],
+    hostdir_or_volname: Path | str,
     contdir: Path,
     options: Optional[Sequence[str]] = None,
 ) -> str:

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 import subprocess
 import json
-from typing import Any, IO, Sequence
+from typing import Any, IO, Sequence, TypeAlias
 from pathlib import Path
 
 # https://github.com/python/typeshed/blob/main/stdlib/subprocess.pyi
-_CMD = str | bytes | Sequence[str | bytes]
-_FILE = None | int | IO[Any]
+_CMD: TypeAlias = str | bytes | Sequence[str | bytes]
+_FILE: TypeAlias = None | int | IO[Any]
 
 
 class DockerError(Exception):

--- a/scuba/dockerutil.py
+++ b/scuba/dockerutil.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import subprocess
 import json
-from typing import Any, IO, Optional, Sequence
+from typing import Any, IO, Sequence
 from pathlib import Path
 
 # https://github.com/python/typeshed/blob/main/stdlib/subprocess.pyi
@@ -110,7 +110,7 @@ def get_images() -> Sequence[str]:
     return cp.stdout.splitlines()
 
 
-def _get_image_config(image: str, key: str) -> Optional[Sequence[str]]:
+def _get_image_config(image: str, key: str) -> Sequence[str] | None:
     info = docker_inspect_or_pull(image)
     try:
         result = info["Config"].get(key)
@@ -121,12 +121,12 @@ def _get_image_config(image: str, key: str) -> Optional[Sequence[str]]:
     return result
 
 
-def get_image_command(image: str) -> Optional[Sequence[str]]:
+def get_image_command(image: str) -> Sequence[str] | None:
     """Gets the default command for an image"""
     return _get_image_config(image, "Cmd")
 
 
-def get_image_entrypoint(image: str) -> Optional[Sequence[str]]:
+def get_image_entrypoint(image: str) -> Sequence[str] | None:
     """Gets the image entrypoint"""
     return _get_image_config(image, "Entrypoint")
 
@@ -134,7 +134,7 @@ def get_image_entrypoint(image: str) -> Optional[Sequence[str]]:
 def make_vol_opt(
     hostdir_or_volname: Path | str,
     contdir: Path,
-    options: Optional[Sequence[str]] = None,
+    options: Sequence[str] | None = None,
 ) -> str:
     """Generate a docker volume option"""
     if isinstance(hostdir_or_volname, Path):

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -9,8 +9,7 @@ import tempfile
 from grp import getgrgid
 from pathlib import Path
 from pwd import getpwuid
-from typing import cast, Any, Iterable, Sequence
-from typing import TextIO
+from typing import cast, Any, Iterable, Sequence, TextIO, TypeAlias
 
 from .config import ScubaConfig, OverrideMixin
 from .config import ConfigError, ScubaVolume
@@ -19,7 +18,7 @@ from .dockerutil import get_image_entrypoint
 from .dockerutil import make_vol_opt
 from .utils import shell_quote_cmd, flatten_list, get_umask, writeln
 
-VolumeTuple = tuple[Path, Path, list[str]]
+VolumeTuple: TypeAlias = tuple[Path, Path, list[str]]
 
 
 class ScubaError(Exception):

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -9,7 +9,7 @@ import tempfile
 from grp import getgrgid
 from pathlib import Path
 from pwd import getpwuid
-from typing import cast, Any, Iterable, Optional, Sequence
+from typing import cast, Any, Iterable, Sequence
 from typing import TextIO
 
 from .config import ScubaConfig, OverrideMixin
@@ -41,13 +41,13 @@ class ScubaDive:
         config: ScubaConfig,
         top_path: Path,
         top_rel: Path,
-        docker_args: Optional[list[str]] = None,
-        env: Optional[dict[str, str]] = None,
+        docker_args: list[str] | None = None,
+        env: dict[str, str] | None = None,
         as_root: bool = False,
         verbose: bool = False,
-        image_override: Optional[str] = None,
-        entrypoint: Optional[str] = None,
-        shell_override: Optional[str] = None,
+        image_override: str | None = None,
+        entrypoint: str | None = None,
+        shell_override: str | None = None,
         keep_tempfiles: bool = False,
     ):
         self.as_root = as_root
@@ -60,10 +60,10 @@ class ScubaDive:
         self.volumes = []
         self.options = []
         self.docker_args = docker_args or []
-        self.workdir: Optional[Path] = None
+        self.workdir: Path | None = None
 
-        self.__scubadir_hostpath: Optional[str] = None
-        self.__scubadir_contpath: Optional[str] = None
+        self.__scubadir_hostpath: str | None = None
+        self.__scubadir_contpath: str | None = None
         self.config = config
 
         # Mount scuba root directory at the same path in the container...
@@ -143,7 +143,7 @@ class ScubaDive:
         self,
         hostpath: Path | str,
         contpath: Path | str,
-        options: Optional[list[str]] = None,
+        options: list[str] | None = None,
     ) -> None:
         """Add a volume (bind-mount) to the docker run invocation"""
         hostpath = Path(hostpath)
@@ -379,8 +379,8 @@ class ScubaContext:
     volumes: dict[Path, ScubaVolume]
     shell: str
     docker_args: list[str]
-    script: Optional[list[str]] = None  # TODO: drop Optional?
-    entrypoint: Optional[str] = None
+    script: list[str] | None = None  # TODO: drop None type?
+    entrypoint: str | None = None
     as_root: bool = False
 
     @classmethod
@@ -388,8 +388,8 @@ class ScubaContext:
         cls,
         cfg: ScubaConfig,
         command: Sequence[str],
-        image_override: Optional[str] = None,
-        shell_override: Optional[str] = None,
+        image_override: str | None = None,
+        shell_override: str | None = None,
     ) -> ScubaContext:
         """Processes a user command using aliases
 

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -9,7 +9,7 @@ import tempfile
 from grp import getgrgid
 from pathlib import Path
 from pwd import getpwuid
-from typing import cast, Any, Iterable, Optional, Sequence, Union
+from typing import cast, Any, Iterable, Optional, Sequence
 from typing import TextIO
 
 from .config import ScubaConfig, OverrideMixin
@@ -133,7 +133,7 @@ class ScubaDive:
     def is_remote_docker(self) -> bool:
         return "DOCKER_HOST" in os.environ
 
-    def add_env(self, name: str, val: Union[str, int]) -> None:
+    def add_env(self, name: str, val: str | int) -> None:
         """Add an environment variable to the docker run invocation"""
         if name in self.env_vars:
             raise KeyError(name)
@@ -141,8 +141,8 @@ class ScubaDive:
 
     def add_volume(
         self,
-        hostpath: Union[Path, str],
-        contpath: Union[Path, str],
+        hostpath: Path | str,
+        contpath: Path | str,
         options: Optional[list[str]] = None,
     ) -> None:
         """Add a volume (bind-mount) to the docker run invocation"""

--- a/scuba/utils.py
+++ b/scuba/utils.py
@@ -1,7 +1,7 @@
 import os
 from shlex import quote as shell_quote
 import string
-from typing import Iterable, TextIO, Tuple
+from typing import Iterable, TextIO
 
 
 def shell_quote_cmd(cmdlist: Iterable[str]) -> str:
@@ -39,7 +39,7 @@ def format_cmdline(args: Iterable[str], maxwidth: int = 80) -> str:
     return " \\\n".join(lines())
 
 
-def parse_env_var(s: str) -> Tuple[str, str]:
+def parse_env_var(s: str) -> tuple[str, str]:
     """Parse an environment variable string
 
     Returns a key-value tuple

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -15,7 +14,7 @@ SCUBA_YML = Path(".scuba.yml")
 GITLAB_YML = Path(".gitlab.yml")
 
 
-def load_config(*, config_text: Optional[str] = None) -> scuba.config.ScubaConfig:
+def load_config(*, config_text: str | None = None) -> scuba.config.ScubaConfig:
     if config_text is not None:
         SCUBA_YML.write_text(config_text)
     return scuba.config.load_config(SCUBA_YML, Path.cwd())
@@ -23,8 +22,8 @@ def load_config(*, config_text: Optional[str] = None) -> scuba.config.ScubaConfi
 
 def invalid_config(
     *,
-    config_text: Optional[str] = None,
-    error_match: Optional[str] = None,
+    config_text: str | None = None,
+    error_match: str | None = None,
 ) -> None:
     with pytest.raises(scuba.config.ConfigError, match=error_match) as e:
         load_config(config_text=config_text)

--- a/tests/test_dockerutil.py
+++ b/tests/test_dockerutil.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
 import subprocess
-from typing import Optional, Sequence
+from typing import Sequence
 from unittest import mock
 
 from .const import ALT_DOCKER_IMAGE, DOCKER_IMAGE
@@ -12,7 +12,7 @@ import scuba.dockerutil as uut
 def _mock_subprocess_run(  # type: ignore[no-untyped-def]
     stdout: str,
     returncode: int = 0,
-    expected_args: Optional[Sequence[str]] = None,
+    expected_args: Sequence[str] | None = None,
 ):  # -> mock._patch[mock.MagicMock]:
     def mocked_run(args, **kwargs):  # type: ignore[no-untyped-def]
         assert expected_args is None or args == expected_args

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from tempfile import TemporaryFile, NamedTemporaryFile
 from textwrap import dedent
-from typing import cast, IO, Sequence, TextIO
+from typing import cast, IO, Sequence, TextIO, TypeAlias
 from unittest import mock
 import warnings
 
@@ -28,7 +28,7 @@ from .utils import (
     PseudoTTY,
 )
 
-ScubaResult = tuple[str, str]
+ScubaResult: TypeAlias = tuple[str, str]
 
 
 SCUBA_YML = Path(".scuba.yml")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from tempfile import TemporaryFile, NamedTemporaryFile
 from textwrap import dedent
-from typing import cast, IO, Optional, Sequence, TextIO
+from typing import cast, IO, Sequence, TextIO
 from unittest import mock
 import warnings
 
@@ -45,7 +45,7 @@ def run_scuba(
     *,
     expect_return: int = 0,
     mock_isatty: bool = False,
-    stdin: Optional[IO[str]] = None,
+    stdin: IO[str] | None = None,
 ) -> ScubaResult:
     """Run scuba, checking its return value
 
@@ -137,7 +137,7 @@ class TestMainBasic(MainTest):
         """Verify scuba handles a get_image_command error"""
         SCUBA_YML.write_text("image: {DOCKER_IMAGE}")
 
-        def mocked_gic(image: str) -> Optional[Sequence[str]]:
+        def mocked_gic(image: str) -> Sequence[str] | None:
             raise scuba.dockerutil.DockerError("mock error")
 
         # http://alexmarandon.com/articles/python_mock_gotchas/#patching-in-the-wrong-place

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,12 +7,12 @@ import shutil
 import unittest
 import logging
 from pathlib import Path
-from typing import Any, Callable, Sequence, TypeVar, Optional, Union
+from typing import Any, Callable, Sequence, TypeVar, Optional
 from unittest import mock
 
 from scuba.config import ScubaVolume
 
-PathStr = Union[Path, str]
+PathStr = Path | str
 
 _FT = TypeVar("_FT", bound=Callable[..., Any])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,12 +7,12 @@ import shutil
 import unittest
 import logging
 from pathlib import Path
-from typing import Any, Callable, Sequence, TypeVar
+from typing import Any, Callable, Sequence, TypeAlias, TypeVar
 from unittest import mock
 
 from scuba.config import ScubaVolume
 
-PathStr = Path | str
+PathStr: TypeAlias = Path | str
 
 _FT = TypeVar("_FT", bound=Callable[..., Any])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ import shutil
 import unittest
 import logging
 from pathlib import Path
-from typing import Any, Callable, Sequence, TypeVar, Optional
+from typing import Any, Callable, Sequence, TypeVar
 from unittest import mock
 
 from scuba.config import ScubaVolume
@@ -86,7 +86,7 @@ class InTempDir:
         self,
         suffix: str = "",
         prefix: str = "tmp",
-        dir: Optional[PathStr] = None,
+        dir: PathStr | None = None,
         delete: bool = True,
     ):
         self.delete = delete


### PR DESCRIPTION
With Python 3.9 out of the way (#270) we can use some nice features of Python 3.10:

* Using `X | Y` instead of `Union[X, Y]`
* Using `X | None` instead of `Optional[X]`
* `typing.TypeAlias`