### PR TITLE
Add aarch64 support to scubainit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: False
 
     steps:
@@ -58,7 +59,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: Unit Test Results (Python ${{ matrix.python-version }})
+        name: Unit Test Results (${{ matrix.runner }}, Python ${{ matrix.python-version }})
         path: unit-test-results.xml
 
   # https://github.com/marketplace/actions/publish-unit-test-results#use-with-matrix-strategy

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
     - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,12 @@ information you desire.*
 
 1. Download and install [docker-ce](https://docs.docker.com/engine/install/debian/#install-using-the-repository)
 2. Download and install [rust](https://www.rust-lang.org/tools/install)
+	1. Run `rustup default stable`
+	2. Run `rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl`
 <!-- Specific python version? -->
 3. Download and install python3 and pip
 4. Run `source ./dev_bootstrap.sh`
-5. Run `test-docker-images/build_all.sh`
+5. Run `./test-docker-images/build_all.sh`
 
 ## Build and test
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 .PHONY: all
-all: scuba/scubainit
+all: scuba/scubainit-all
+
+SCUBAINIT_BIN_TARGETS := x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 
 .PHONY: scubainit  # Defer dependency-tracking to Cargo
 scubainit:
 	make -C $@ test scubainit
 
-# Copy the binary into the scuba python package
-scuba/scubainit: scubainit
-	cp $</scubainit $@
+# Copy all architecture variants into the scuba python package
+scuba/scubainit-all: scubainit
+	for target in $(SCUBAINIT_BIN_TARGETS); do \
+		cp scubainit/scubainit-$$target scuba/scubainit-$$target; \
+	done
 
 .PHONY: clean
 clean:
 	make -C scubainit clean
-	rm -f scuba/scubainit
+	rm -f scuba/scubainit-*

--- a/scuba/.gitignore
+++ b/scuba/.gitignore
@@ -1,1 +1,1 @@
-scubainit
+scubainit-*

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -15,6 +15,7 @@ from .config import ScubaConfig, OverrideMixin
 from .config import ConfigError, ScubaVolume
 from .dockerutil import get_image_command
 from .dockerutil import get_image_entrypoint
+from .dockerutil import docker_inspect_or_pull
 from .dockerutil import make_vol_opt
 from .utils import shell_quote_cmd, flatten_list, get_umask, writeln
 
@@ -183,13 +184,37 @@ class ScubaDive:
         self.workdir = workdir
 
     def __locate_scubainit(self) -> str:
-        """Determine path to scubainit binary"""
+        """Determine path to the scubainit binary matching container architecture."""
         pkg_path = os.path.dirname(__file__)
+        arch = self.__get_container_architecture()
+        target = f"{arch}-unknown-linux-musl"
 
-        scubainit_path = os.path.join(pkg_path, "scubainit")
-        if not os.path.isfile(scubainit_path):
-            raise ScubaError(f"scubainit not found at {scubainit_path!r}")
-        return scubainit_path
+        scubainit_path = os.path.join(pkg_path, f"scubainit-{target}")
+        if os.path.isfile(scubainit_path):
+            return scubainit_path
+
+        raise ScubaError(
+            f"scubainit binary not found for container target {target!r}"
+        )
+
+    def __normalize_architecture(self, arch: str) -> str | None:
+        return {
+            "amd64": "x86_64",
+            "x86_64": "x86_64",
+            "arm64": "aarch64",
+            "aarch64": "aarch64",
+        }.get(arch.lower())
+
+    def __get_container_architecture(self) -> str:
+        image_info = docker_inspect_or_pull(self.context.image)
+        arch = image_info.get("Architecture")
+        if not isinstance(arch, str):
+            raise ScubaError("Could not determine container architecture from image")
+
+        normalized_arch = self.__normalize_architecture(arch)
+        if normalized_arch is None:
+            raise ScubaError(f"Unsupported container architecture: {arch!r}")
+        return normalized_arch
 
     def __make_scubadir(self) -> None:
         """Make temp directory where all ancillary files are bind-mounted"""

--- a/scubainit/.cargo/config.toml
+++ b/scubainit/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+linker = "rust-lld"
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"

--- a/scubainit/.gitignore
+++ b/scubainit/.gitignore
@@ -1,3 +1,3 @@
 target/
-scubainit
-scubainit-debug
+scubainit-*
+scubainit-debug-*

--- a/scubainit/Makefile
+++ b/scubainit/Makefile
@@ -7,10 +7,11 @@ help:
 	@echo "  fmt      Check code formatting"
 	@echo "  help     Display this help"
 	@echo "  lint     Lint code (using clippy)"
+	@echo "  setup    Install Rust toolchain support for all targets"
 	@echo "  test     Run unit + integration tests"
 	@echo ""
-	@echo "  scubainit        Release build"
-	@echo "  scubainit-debug  Debug build"
+	@echo "  scubainit        Release build for all supported targets"
+	@echo "  scubainit-debug  Debug build for all supported targets"
 	@echo ""
 	@false
 
@@ -19,7 +20,8 @@ all: test  # Build this first to catch compile errors faster
 all: scubainit-debug
 all: scubainit
 
-TARGET=x86_64-unknown-linux-musl
+SUPPORTED_TARGETS := x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+TARGETS ?= $(SUPPORTED_TARGETS)
 
 # Enable static linking
 STATIC_RUSTFLAGS=-C relocation-model=static
@@ -45,23 +47,35 @@ fmt:
 scubainit-debug: PROFILE=debug
 scubainit-debug: RUSTFLAGS=$(STATIC_RUSTFLAGS)
 scubainit-debug: setup
-	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) with RUSTFLAGS=\"$$RUSTFLAGS\""
-	cargo build --target $(TARGET)
-	cp target/x86_64-unknown-linux-musl/$(PROFILE)/scubainit $@
+scubainit-debug: $(patsubst %,scubainit-debug-%,$(TARGETS))
+
+.PHONY: scubainit-debug-%  # always build
+scubainit-debug-%: PROFILE=debug
+scubainit-debug-%: RUSTFLAGS=$(STATIC_RUSTFLAGS)
+scubainit-debug-%:
+	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) for $* with RUSTFLAGS=\"$$RUSTFLAGS\""
+	cargo build --target $*
+	cp target/$*/$(PROFILE)/scubainit $@
 
 .PHONY: scubainit  # always build
 scubainit: PROFILE=release
 scubainit: RUSTFLAGS=$(STATIC_RUSTFLAGS)
 scubainit: setup
-	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) with RUSTFLAGS=\"$$RUSTFLAGS\""
-	cargo build --target $(TARGET) --release
-	cp target/x86_64-unknown-linux-musl/$(PROFILE)/scubainit $@
+scubainit: $(patsubst %,scubainit-%,$(TARGETS))
+
+.PHONY: scubainit-%  # always build
+scubainit-%: PROFILE=release
+scubainit-%: RUSTFLAGS=$(STATIC_RUSTFLAGS)
+scubainit-%:
+	@/bin/echo -e "\nBuilding scubainit ($(PROFILE)) for $* with RUSTFLAGS=\"$$RUSTFLAGS\""
+	cargo build --target $* --release
+	cp target/$*/$(PROFILE)/scubainit $@
 
 .PHONY: setup  # always run
 setup:
-	rustup target add $(TARGET)
+	rustup target add $(TARGETS)
 
 
 .PHONY: clean
 clean:
-	rm -rf target/ scubainit scubainit-debug
+	rm -rf target/ scubainit-* scubainit-debug-*

--- a/scubainit/README
+++ b/scubainit/README
@@ -2,8 +2,9 @@
 Resources for building small, static binaries:
 
 - https://stackoverflow.com/a/31778003/119527
-  rustup target add x86_64-unknown-linux-musl
+  rustup target add x86_64-unknown-linux-musl    # or aarch64-unknown-linux-musl
   RUSTFLAGS='-C relocation-model=static -C strip=symbols' cargo build --release --target x86_64-unknown-linux-musl
+  RUSTFLAGS='-C relocation-model=static -C strip=symbols' cargo build --release --target aarch64-unknown-linux-musl
 
 - https://stackoverflow.com/a/54842093/119527
   Cargo.toml [profile.release] options

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     packages=["scuba"],
     package_data={
         "scuba": [
-            "scubainit",
+            "scubainit-*",
         ],
     },
     include_package_data=True,  # https://github.com/pypa/setuptools/issues/1064


### PR DESCRIPTION
Implement multi-architecture support for scubainit.

- build scubainit for the aarch64 musl target
- scuba detects which scubainit to use based on image architecture since some hosts (MacOS) can run containers for architectures other than what their cpu supports.
- fix cross-target linking by configuring rust-lld for musl targets
- add rustup target setup and multi-arch build steps to CONTRIBUTING.mg

This was mostly put together so that I can locally use scuba for development on my aarch64 machine. Would be really cool to get builds for aarch64 up on pypi though.

Previously:
```sh
$ scuba --image alpine:latest
exec /.scuba/scubainit: exec format error
```
Now:
```sh
~$ scuba --image alpine:latest
~ $ uname -a
Linux 26650320bf60 6.12.90+deb13.1-arm64 #1 SMP Debian 6.12.90-2 (2026-05-27) aarch64 Linux
```